### PR TITLE
Recycle MySQL connections every 5 minutes

### DIFF
--- a/montage/server.py
+++ b/montage/server.py
@@ -86,7 +86,12 @@ def create_app(env_name='prod'):
     logging.basicConfig()
     logging.getLogger('sqlalchemy.engine').setLevel(logging.WARN)
 
-    engine = create_engine(config.get('db_url', DEFAULT_DB_URL))
+    # Recycle connections after 5 minutes, since MySQL is usually configed to kill
+    # long running idle connections at some interval. 5 is perhaps too aggressive,
+    # but eh. See http://docs.sqlalchemy.org/en/rel_1_0/core/pooling.html#setting-pool-recycle
+    # for more details
+    # FIXME: Make this configurable
+    engine = create_engine(config.get('db_url', DEFAULT_DB_URL), pool_recycle=300)
     session_type = sessionmaker()
     session_type.configure(bind=engine)
     tmp_rdb_session = session_type()


### PR DESCRIPTION
MySQL will consider all connections that have been idle for a specific time
period to be 'stale' and close them. We work around this by telling
SQLAlchemy to recycle old connections (disconnect/reconnect) after 5
minutes of having started them. MySQL connections are cheapish enough
that this works ok.