### PR TITLE
Correct two minor typos on login page

### DIFF
--- a/client/src/components/login/login.html
+++ b/client/src/components/login/login.html
@@ -3,11 +3,11 @@
   <md-card layout="column" layout-align="start stretch">
     <h3 class="login__title">Please log in</h3>
     <p class="muted">
-      You will be redirected to Meta-Wiki in order to confirm your indentity.
+      You will be redirected to Meta-Wiki in order to confirm your identity.
       Montage will not publish anything on Wikimedia projects using your account.
     </p>
     <p class="muted">
-      If you don't have Wikimedia account, you can create one by clicking "Join Meta".
+      If you don't have a Wikimedia account, you can create one by clicking "Join Meta".
     </p>
   </md-card>
   <md-button class="md-primary"


### PR DESCRIPTION
A couple small things noticed while logging in:

* "indentity" -> "identity"
* "If you don't have Wikimedia account" -> "If you don't have a Wikimedia account"