### PR TITLE
Hiding inactive campaigns (Archive flag)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "montage",
-  "version": "19.09.23",
+  "version": "20.09.17",
   "description": "Photo evaluation tool for and by Wiki Loves competitions",
   "main": "src/app.module.js",
   "repository": "https://github.com/hatnote/montage",

--- a/client/src/app.module.js
+++ b/client/src/app.module.js
@@ -26,7 +26,7 @@ import campaignNew from './components/campaign-new/campaign-new.component';
 import campaignOld from './components/campaign-old/campaign';
 
 import dashboard from './components/dashboard/dashboard';
-import archive from './components/dashboard/archive';
+import all_campaigns from './components/dashboard/all_campaigns';
 import campaignAdminBox from './components/dashboard/campaign-admin-box/campaign-admin-box.component';
 import campaignJurorBox from './components/dashboard/campaign-juror-box/campaign-juror-box.component';
 import footer from './components/footer/footer.component';
@@ -84,7 +84,7 @@ angular.module('montage',
   .component('montCampaignAdminBox', campaignAdminBox)
   .component('montCampaignJurorBox', campaignJurorBox)
   .component('montDashboard', dashboard)
-  .component('montArchive', archive)
+  .component('montCampaignsAll', all_campaigns)
   .component('montFooter', footer)
 
   .component('montVote', vote)

--- a/client/src/app.routing.js
+++ b/client/src/app.routing.js
@@ -10,9 +10,9 @@ function stateConfig(
       url: '/',
       template: '<mont-dashboard></mont-dashboard>',
     })
-    .state('main.archive', {
-      url: '/archive',
-      template: '<mont-archive></mont-archive>',
+    .state('main.campaigns-all', {
+      url: '/campaigns/all',
+      template: '<mont-campaigns-all></mont-campaigns-all>',
     })
     .state('main.campaign-new', {
       url: '/campaign/new',

--- a/client/src/components/campaign/campaign.component.js
+++ b/client/src/components/campaign/campaign.component.js
@@ -16,7 +16,8 @@ function controller($filter, $q, $state, $stateParams, adminService, alertServic
   vm.newRound = false;
 
   vm.closeCampaign = closeCampaign;
-  vm.reopenCampaign = reopenCampaign;
+  vm.archiveCampaign = archiveCampaign;
+  vm.unarchiveCampaign = unarchiveCampaign;
   vm.editCampaign = editCampaign;
   vm.saveEditCampaign = saveEditCampaign;
 
@@ -38,7 +39,6 @@ function controller($filter, $q, $state, $stateParams, adminService, alertServic
         }
 
         vm.canCloseCampaign = vm.campaign.status === CAMPAIGN_STATUS_ACTIVE;
-        vm.canReopenCampaign = vm.campaign.status === CAMPAIGN_STATUS_FINALIZED;
       })
       .catch((err) => {
         vm.err = err;
@@ -80,10 +80,23 @@ function controller($filter, $q, $state, $stateParams, adminService, alertServic
       });
   }
 
-  function reopenCampaign() {
+  function archiveCampaign() {
     vm.loading = true;
+    let data = {'is_archived': true}
     adminService
-      .reopenCampaign(vm.campaign.id)
+      .editCampaign(vm.campaign.id, data)
+      .then(() => $state.reload())
+      .catch(alertService.error)
+      .finally(() => {
+        vm.loading = false;
+      });
+  }
+
+  function unarchiveCampaign() {
+    vm.loading = true;
+    let data = {'is_archived': false}
+    adminService
+      .editCampaign(vm.campaign.id, data)
       .then(() => $state.reload())
       .catch(alertService.error)
       .finally(() => {

--- a/client/src/components/campaign/campaign.html
+++ b/client/src/components/campaign/campaign.html
@@ -42,13 +42,22 @@
         Close Campaign
       </md-button>
       <md-button
-        aria-label="Reopen Campaign"
-        ng-if="!$ctrl.edit && $ctrl.canReopenCampaign"
-        ng-click="$ctrl.reopenCampaign()"
+        aria-label="Archive Campaign"
+        ng-if="!$ctrl.edit && !$ctrl.campaign.is_archived"
+        ng-click="$ctrl.archiveCampaign()"
       >
-        <md-icon>assignment_turned_in</md-icon>
-        Reopen Campaign
+        <md-icon>archive</md-icon>
+        Archive Campaign
       </md-button>
+      <md-button
+        aria-label="Unarchive Campaign"
+        ng-if="!$ctrl.edit && $ctrl.campaign.is_archived"
+        ng-click="$ctrl.unarchiveCampaign()"
+      >
+        <md-icon>inbox</md-icon>
+        Unarchive Campaign
+      </md-button>
+
       <md-button
         aria-label="Edit Campaign"
         ng-if="!$ctrl.edit"

--- a/client/src/components/dashboard/all_campaigns.js
+++ b/client/src/components/dashboard/all_campaigns.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import './dashboard.scss';
-import template from './archive.tpl.html';
+import template from './all_campaigns.tpl.html';
 
 const Component = {
   controller,
@@ -26,7 +26,7 @@ function controller(
 
   function getAdminData() {
     adminService
-       .archive()
+       .allCampaigns()
       .then(data => {
         vm.campaignsAdmin = data.data;
       })
@@ -37,7 +37,7 @@ function controller(
 
   function getJurorData() {
     jurorService
-      .archive()
+      .allCampaigns()
       .then(data => {
         if (!data.data.length) {
           return;

--- a/client/src/components/dashboard/all_campaigns.tpl.html
+++ b/client/src/components/dashboard/all_campaigns.tpl.html
@@ -1,4 +1,4 @@
-<h1>Archive of old campaigns</h1>
+<h1>All Campaigns</h1>
 <div class="dashboard__section dashboard__section--admin" ng-if="$ctrl.campaignsAdmin">
   <h2>Coordinator campaigns</h2>
   <div class="section__content">

--- a/client/src/components/dashboard/all_campaigns.tpl.html
+++ b/client/src/components/dashboard/all_campaigns.tpl.html
@@ -1,4 +1,5 @@
 <h1>All Campaigns</h1>
+<p>View all campaigns, active and archived below, or <a ui-sref="main.dashboard">view only active campaigns and rounds</a>.</p>
 <div class="dashboard__section dashboard__section--admin" ng-if="$ctrl.campaignsAdmin">
   <h2>Coordinator campaigns</h2>
   <div class="section__content">
@@ -12,7 +13,7 @@
 </div>
 
 <div class="dashboard__section" ng-if="$ctrl.campaignsJuror">
-  <h2>Juror campaigns</h2>
+  <h1>Juror campaigns</h1>
   <div class="section__content">
     <mont-campaign-juror-box
       ng-repeat="campaign in $ctrl.campaignsJuror"

--- a/client/src/components/dashboard/all_campaigns.tpl.html
+++ b/client/src/components/dashboard/all_campaigns.tpl.html
@@ -13,7 +13,7 @@
 </div>
 
 <div class="dashboard__section" ng-if="$ctrl.campaignsJuror">
-  <h1>Juror campaigns</h1>
+  <h2>Juror campaigns</h2>
   <div class="section__content">
     <mont-campaign-juror-box
       ng-repeat="campaign in $ctrl.campaignsJuror"

--- a/client/src/components/dashboard/dashboard.tpl.html
+++ b/client/src/components/dashboard/dashboard.tpl.html
@@ -1,7 +1,7 @@
 <div class="dashboard__section dashboard__section--admin"
     ng-if="$ctrl.campaignsAdmin">
-  <h2 class="section__title">Hello {{ $ctrl.user.username }}!</h2>
-  <p>Resume voting on current campaigns</p>
+  <h1 class="section__title">Active Campaigns</h1>
+  <p>Manage current campaigns below, or <a ui-sref="main.campaigns-all">view all campaigns and rounds</a>. </p>
   <div class="section__content">
     <mont-campaign-admin-box
       ng-repeat="campaign in $ctrl.campaignsAdmin | orderBy : 'id' : true"
@@ -19,6 +19,10 @@
 </div>
 
 <div class="dashboard__section">
+  <div ng-if="!$ctrl.err.length">
+    <h1 class="section__title">Active Voting Rounds</h1>
+    <p>Vote on currently open rounds.</p>
+  </div>
   <div class="section__content">
     <mont-campaign-juror-box
       ng-repeat="campaign in $ctrl.campaignsJuror"
@@ -26,10 +30,12 @@
     >
     </mont-campaign-juror-box>
   </div>
-  <md-button aria-label="View all campaigns" ui-sref="main.campaigns-all" ng-if="!$ctrl.err.length">
-    View all campaigns
-  </md-button>
 </div>
+
+<md-button aria-label="View all campaigns" ui-sref="main.campaigns-all" ng-if="!$ctrl.err.length">
+  View all campaigns and rounds
+</md-button>
+
 
 <div flex></div>
 <div layout="row" layout-align="end end" ng-if="$ctrl.user.is_maintainer">

--- a/client/src/components/dashboard/dashboard.tpl.html
+++ b/client/src/components/dashboard/dashboard.tpl.html
@@ -26,11 +26,10 @@
     >
     </mont-campaign-juror-box>
   </div>
+  <md-button aria-label="View all campaigns" ui-sref="main.campaigns-all" ng-if="!$ctrl.err.length">
+    View all campaigns
+  </md-button>
 </div>
-
-<md-button aria-label="View archive" ui-sref="main.archive">
-    View archive
-</md-button>
 
 <div flex></div>
 <div layout="row" layout-align="end end" ng-if="$ctrl.user.is_maintainer">

--- a/client/src/components/toolbar/toolbar.component.js
+++ b/client/src/components/toolbar/toolbar.component.js
@@ -25,9 +25,6 @@ function controller($state, $window, userService) {
   // functions
 
   vm.$onInit = () => {
-    userService.getAdmin();
-    userService.getJuror();
-
     userService.getUser()
       .then((data) => { vm.user = data; });
   };

--- a/client/src/services/admin.service.js
+++ b/client/src/services/admin.service.js
@@ -3,7 +3,7 @@ const Service = ($http, $q, $window) => {
 
   const admin = {
     get: () => $http.get(base),
-    archive: () => $http.get(base + '/archive'),
+    allCampaigns: () => $http.get(base + '/campaigns/all'),
     getCampaign: id => $http.get([base, 'campaign', id].join('/')),
     getRound: id => $http.get([base, 'round', id].join('/')),
 
@@ -11,7 +11,6 @@ const Service = ($http, $q, $window) => {
     addCampaign: data => $http.post(`${base}/add_campaign`, data),
     addRound: (id, data) => $http.post(`${base}/campaign/${id}/add_round`, data),
     finalizeCampaign: id => $http.post(`${base}/campaign/${id}/finalize`, { post: true }),
-    reopenCampaign: id => $http.post(`${base}/campaign/${id}/reopen`, { post: true }),
     addCoordinator: (id, username) =>
       $http.post(`${base}/campaign/${id}/add_coordinator`, { username }),
     removeCoordinator: (id, username) =>

--- a/client/src/services/juror.service.js
+++ b/client/src/services/juror.service.js
@@ -5,8 +5,8 @@ const UserService = ($http, $q, $window, dataService) => {
 
   const juror = {
     get: () => $http.get(base + '/juror'),
-    archive: () => $http.get(base + '/juror/archive'),
     getCampaign: id => $http.get(base + '/juror/campaign/' + id),
+    allCampaigns: () => $http.get(base + '/juror/campaigns/all'),
     getPastVotes: (id, offset, orderBy, sort) => $http.get([
       base, 'juror/round', id,
       `votes?offset=${offset || 0}&order_by=${orderBy || 'date'}&sort=${sort || 'desc'}`,

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -636,7 +636,7 @@ def reopen_campaign(user_dao, campaign_id):
     coord_dao.reopen_campaign()
 
 
-def get_index(user_dao, state='active', include_archived=False):
+def get_index(user_dao, only_active=True):
     """
     Summary: Get admin-level details for all campaigns.
 
@@ -650,7 +650,7 @@ def get_index(user_dao, state='active', include_archived=False):
     Errors:
        403: User does not have permission to access any campaigns
     """
-    campaigns = user_dao.get_all_campaigns(state, include_archived=include_archived)
+    campaigns = user_dao.get_all_campaigns(only_active=only_active)
     data = []
 
     for campaign in campaigns:
@@ -660,7 +660,7 @@ def get_index(user_dao, state='active', include_archived=False):
 
 
 def get_all_campaigns(user_dao):
-    return get_index(user_dao, state=None, include_archived=True)
+    return get_index(user_dao, only_active=False)
 
 
 def get_campaigns(user_dao):

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -274,6 +274,7 @@ def get_campaign_report(user_dao, campaign_id):
     ctx['use_ashes'] = True
     return ctx
 
+
 def get_campaign_report_raw(user_dao, campaign_id):
     coord_dao = CoordinatorDAO.from_campaign(user_dao, campaign_id)
     summary = coord_dao.get_campaign_report()
@@ -626,6 +627,7 @@ def finalize_campaign(user_dao, campaign_id):
         raise InvalidAction('only ranking rounds can be finalized')
 
     campaign_summary = coord_dao.finalize_ranking_round(last_rnd.id)
+    coord_dao.finalize_campaign()
     return campaign_summary
 
 

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -619,10 +619,13 @@ def finalize_campaign(user_dao, campaign_id):
     coord_dao = CoordinatorDAO.from_campaign(user_dao, campaign_id)
     last_rnd = coord_dao.campaign.active_round
 
-    campaign_summary = None
-    if last_rnd and last_rnd.vote_method == 'ranking':
-        campaign_summary = coord_dao.finalize_ranking_round(last_rnd.id)
-    coord_dao.finalize_campaign()
+    if not last_rnd:
+        raise InvalidAction('no active rounds')
+
+    if last_rnd.vote_method != 'ranking':
+        raise InvalidAction('only ranking rounds can be finalized')
+
+    campaign_summary = coord_dao.finalize_ranking_round(last_rnd.id)
     return campaign_summary
 
 

--- a/montage/juror_endpoints.py
+++ b/montage/juror_endpoints.py
@@ -73,13 +73,12 @@ def make_juror_round_details(rnd, rnd_stats, ballot):
 
 # Endpoint functions
 
-def get_index(user_dao, status='active', include_archived=False):
+def get_index(user_dao, only_active=True):
     """
     Summary: Get juror-level index of active campaigns and rounds.
     """
     juror_dao = JurorDAO(user_dao)
-    counts = juror_dao.get_all_rounds_task_counts(status,
-                                                  include_archived=include_archived)
+    counts = juror_dao.get_all_rounds_task_counts(only_active=True)
     stats = [make_juror_round_details(rnd, rnd_stats, ballot)
              for rnd, rnd_stats, ballot in counts]
     return stats
@@ -89,7 +88,7 @@ def get_all_campaigns(user_dao):
     """
     Summary: Get juror-level archive of finalized campaigns and rounds.
     """
-    return get_index(user_dao, status=None, include_archived=True)
+    return get_index(user_dao, only_active=False)
 
 
 def get_campaign(user_dao, campaign_id):


### PR DESCRIPTION
Rather than coopt the status field of the Campaign table, as in #169, this PR introduces a new Archive feature, which hides the campaign from  Jurors' and Coordinators' dashboards. Campaigns in any state can be archived without affecting their status.

Current status is that the backend is tested and passing. Now, need to make the modifications to the frontend.

For rollout:
  * Need to add the column + index
  * Autoarchive campaigns older than a year to save some coordinator clicking?