### PR TITLE
test(e2e): add Cypress tests for login and campaign pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,14 @@ ENV/
 
 # PyCharm stuff:
 .idea/
+
+# Ignore Cypress example tests
+cypress/e2e/1-getting-started/
+cypress/e2e/2-advanced-examples/
+
+# Ignore default fixtures unless used
+cypress/fixtures/example.json
+
+# Ignore screenshots & videos from Cypress runs
+cypress/screenshots/
+cypress/videos/

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+};

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+});

--- a/frontend/cypress/e2e/campaign.cy.js
+++ b/frontend/cypress/e2e/campaign.cy.js
@@ -1,0 +1,115 @@
+describe('Campaign Details Page', () => {
+  beforeEach(() => {
+    cy.setCookie('clastic_cookie', '<cookie-validation-string>');
+    cy.visit('http://localhost:5173/#/')
+    cy.get('div.coordinator-campaign-cards').find('.coordinator-campaign-card').first().click()
+    cy.url().should('match', /\/campaign\/\d+/)
+  })
+
+  it('should display campaign title and rounds section', () => {
+    cy.get('.campaign-title').should('be.visible')
+    cy.get('.campaign-rounds').should('be.visible')
+  })
+
+  it('should enter edit mode and show editable fields', () => {
+    cy.get('.campaign-button-group')
+      .find('button')
+      .contains('Edit campaign')
+      .click()
+
+    cy.get('.campaign-name-input').should('be.visible')
+    cy.get('.date-time-inputs').should('be.visible')
+  })
+
+  it('should cancel edit mode', () => {
+    cy.get('.campaign-button-group')
+      .find('button')
+      .contains('Edit campaign')
+      .click()
+
+    cy.get('.cancel-button').click()
+    cy.get('.campaign-name-input').should('not.exist')
+    cy.get('.campaign-title').should('be.visible')
+  })
+
+  it('should show new round form after clicking "Add Round"', () => {
+    cy.get('.add-round-button').click()
+    cy.get('.juror-campaign-round-card').should('be.visible')
+    cy.get('.form-container').should('be.visible')
+  })
+
+  it('should enter campaign edit mode and show editable fields', () => {
+    cy.get('[datatest="editbutton"]').click()
+    cy.get('.campaign-name-input').should('be.visible')
+    cy.get('.date-time-inputs').should('be.visible')
+  })
+
+   it('should save campaign edits', () => {
+    cy.get('button').contains('Edit').first().click()
+   cy.get('.campaign-name-input input').clear().type('Updated Campaign Name');
+    cy.get('button').contains('Save').click()
+    cy.contains('Updated Campaign Name').should('be.visible')
+  })
+
+  it('should cancel editing campaign details', () => {
+    cy.get('[datatest="editbutton"]').click()
+    cy.get('.cancel-button').click()
+    cy.get('.campaign-name-input').should('not.exist')
+    cy.get('.campaign-title').should('be.visible')
+  })
+
+  it('should not allow creating a new round when one is already active or paused', () => {
+    cy.intercept('GET', '/v1/admin/campaign/*', {
+      fixture: 'campaignWithActiveRound.json'
+    }).as('getCampaign')
+
+    cy.visit('/')
+    cy.get('div.coordinator-campaign-cards').find('.coordinator-campaign-card').first().click()
+    cy.wait('@getCampaign')
+
+    cy.get('.add-round-button').click()
+    cy.contains('Only one round can be maintained at a time').should('be.visible')
+    cy.get('.juror-campaign-round-card').should('not.exist')
+  })
+
+ it('should create a new round successfully', () => {
+  cy.get('.add-round-button').click()
+  cy.get('.form-container input[type="text"]').first().clear().type('My Test Round')
+  cy.get('.form-container').within(() => {
+    cy.get('input[placeholder="YYYY-MM-DD"]').first().clear().type('2025-08-15')
+  })
+  cy.get('input[type="number"]').first().clear().type('3')
+  cy.get('[data-testid="userlist-search"] input').type('AadarshM07');
+  cy.get('[data-testid="userlist-search"]')
+    .find('li')
+    .first()
+    .click();
+    cy.get('.button-group button').contains('Add Round').click().click();
+    cy.log(' Round created successfully');
+})
+
+
+  it('should cancel round creation', () => {
+    cy.get('.add-round-button').click()
+
+    cy.get('.button-group')
+      .find('button')
+      .contains('Cancel')
+      .click()
+
+    cy.get('.juror-campaign-round-card').should('not.exist')
+    cy.get('.add-round-button').should('be.visible')
+  })
+
+ 
+
+  it('should delete a round with confirmation', () => {
+    cy.get('button').contains('Edit round').first().click()
+    cy.get('button').contains('Delete').click()
+    cy.get('.cdx-dialog')
+      .find('button')
+      .contains('Delete')
+      .click()
+    cy.wait(1000)
+  })
+})

--- a/frontend/cypress/e2e/login.cy.js
+++ b/frontend/cypress/e2e/login.cy.js
@@ -1,0 +1,117 @@
+describe('Home View Conditional Rendering', () => {
+
+  beforeEach(() => {
+    cy.setCookie('clastic_cookie','<cookie-validation-string>');
+    cy.visit('http://localhost:5173/#/');
+  })
+  
+  it('should display main dashboard elements', () => {
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist')
+    cy.get('.dashboard-header h1').should('be.visible')
+  })
+
+  it('should show "New Campaign" button for organizers', () => {
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist')
+    cy.get('body').then(($body) => {
+      if ($body.find('a[href="/campaign/new"]').length > 0) {
+        cy.get('.dashboard-header-heading').within(() => {
+          cy.contains('New Campaign').should('exist')
+          cy.get('a[href="/campaign/new"]').should('exist')
+        })
+      }
+    })
+  })
+
+  it('should create a new campaign via the form submission', () => {
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist')
+    cy.get('body').then(($body) => {
+      if ($body.find('a[href="/campaign/new"]').length > 0) {
+        cy.get('a[href="/campaign/new"]').click()
+        cy.url().should('include', '/campaign/new')
+        cy.get('.new-campaign-card').within(() => {
+          cy.get('input[placeholder="Campaign name"]').type('Test Campaign')
+          cy.get('input[placeholder="example-slug"]').type('test-campaign')
+          cy.get('input[placeholder="YYYY-MM-DD"]').eq(0).type('2025-08-01')
+          cy.get('input[placeholder="HH:mm"]').eq(0).type('10:00')          
+          cy.get('input[placeholder="YYYY-MM-DD"]').eq(1).type('2025-08-10')
+          cy.get('input[placeholder="HH:mm"]').eq(1).type('18:00')
+          cy.get('.create-button').click()
+        })
+        cy.url().should('match', /\/campaign\/\d+/)
+      }
+    })
+  })
+
+  it('should show new campaign card after creation', () => {
+    cy.visit('http://localhost:5173/#/');
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist')
+    cy.get('body').then(($body) => {
+      if ($body.find('.new-campaign-card').length > 0) {
+        cy.get('.new-campaign-card').should('be.visible')
+        cy.get('.new-campaign-card h2').should('contain', 'Test Campaign')
+      }
+    })
+  });     
+  
+
+  it('should show "Add Organizer" button for maintainers and it', () => {
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist')
+    cy.get('body').then(($body) => {
+      if ($body.find('button:contains("Add Organizer")').length > 0) {
+        cy.contains('Add Organizer').should('exist')
+
+      }
+    })
+  })
+
+  it('should open dialog when "Add Organizer" button is clicked', () => {
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist')
+    cy.get('body').then(($body) => {
+      if ($body.find('button:contains("Add Organizer")').length > 0) {
+        cy.contains('Add Organizer').click()
+        cy.get('[role="dialog"]', { timeout: 5000 }).should('exist')
+        cy.contains('Add').should('exist')
+      }
+    })
+  })
+
+  it('should display juror campaigns if available', () => {
+    cy.visit('http://localhost:5173/#/');
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist')
+    cy.get('body').then(($body) => {
+      if ($body.find('.juror-campaigns').length > 0) {
+        cy.get('.juror-campaigns h2').should('contain', 'Active voting rounds')
+        cy.get('.juror-campaigns juror-campaign-card').should('exist')
+      }
+    })
+  })
+
+  it('should display coordinator campaign cards if campaigns exist', () => {
+    cy.visit('http://localhost:5173/#/');
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist');
+    cy.get('body').then(($body) => {
+      if ($body.find('section.coordinator-campaigns').length > 0) {
+        cy.get('section.coordinator-campaigns').within(() => {
+          cy.get('h2').should('contain', 'Coordinator campaigns');
+          cy.get('.coordinator-campaign-card').should('exist');
+        });
+      }
+    });
+  });
+
+  it('should navigate to view all campaigns page', () => {
+    cy.get('.dashboard-container', { timeout: 10000 }).should('exist')
+    cy.get('.dashboard-info a').click()
+    cy.url().should('include', '/campaign/all')
+  })
+
+  it('should navigate to campaign details page', () => {
+    cy.get('div.coordinator-campaign-cards')
+      .find('.coordinator-campaign-card') 
+      .first()
+      .click()
+    cy.url().should('match', /\/campaign\/\d+/)
+  })
+  
+
+});

--- a/frontend/cypress/fixtures/example.json
+++ b/frontend/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/frontend/cypress/support/e2e.js
+++ b/frontend/cypress/support/e2e.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/eslint-config-prettier": "^9.0.0",
     "chokidar-cli": "^3.0.0",
+    "cypress": "^14.5.3",
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^9.23.0",
     "prettier": "^3.2.5",

--- a/frontend/src/components/Campaign/ViewCampaign.vue
+++ b/frontend/src/components/Campaign/ViewCampaign.vue
@@ -15,6 +15,7 @@
           </cdx-button>
           <cdx-button
             action="progressive"
+            datatest="editbutton"
             @click="hangleEditCampaignBtnClick"
             :disabled="campaign.is_archived"
           >

--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -56,7 +56,7 @@
                 </template>
               </cdx-field>
               <cdx-field v-if="roundIndex === 0 && selectedImportSource === 'category'">
-                <cdx-lookup v-model:selected="importSourceValue.category" :menu-items="categoryOptions"
+                <cdx-lookup data-testid="montage-round-category" v-model:selected="importSourceValue.category" :menu-items="categoryOptions"
                   :placeholder="$t('montage-round-category-placeholder')" @input="searchCategory">
                   <template #label>{{ $t('montage-round-category-label') }}</template>
                   <template #no-results>{{ $t('montage-round-no-category') }}</template>
@@ -92,7 +92,7 @@
                 </template>
               </cdx-field>
               <cdx-field>
-                <UserList :users="formData.jurors" @update:selectedUsers="formData.jurors = $event" />
+                <UserList :users="formData.jurors" @update:selectedUsers="formData.jurors = $event" data-testid="userlist-search" />
                 <template #label>{{ $t('montage-label-round-jurors') }}</template>
                 <template #help-text>
                   <p>{{ $t('montage-round-jurors-description') }}</p>
@@ -124,7 +124,7 @@
             <cdx-button :disabled="isLoading" action="progressive" weight="primary" @click="submitRound()">
               <check class="icon-small" /> {{ $t('montage-round-add') }}
             </cdx-button>
-            <cdx-button action="destructive" @click="cancelRound()">
+            <cdx-button action="destructive" @click="cancelRound()" data-testid="cancel-round-button">
               <close class="icon-small" /> {{ $t('montage-btn-cancel') }}
             </cdx-button>
           </div>
@@ -313,6 +313,7 @@ const submitRound = () => {
       .advanceRound(prevRound.id, payload)
       .then(() => {
         alertService.success($t('montage-round-added'))
+        console.log('Round created successfully')
       })
       .catch(alertService.error)
       .finally(() => {

--- a/frontend/src/components/UserList.vue
+++ b/frontend/src/components/UserList.vue
@@ -13,7 +13,6 @@
 <script setup>
 import { ref, watch } from 'vue'
 import dataService from '@/services/dataService'
-
 import { CdxMultiselectLookup } from '@wikimedia/codex'
 
 const props = defineProps({


### PR DESCRIPTION
### Document:
This PR introduce comprehensive Cypress end-to-end (E2E) tests focusing on actual user interactions through the UI, avoiding API shortcuts. The goal is to simulate real user behavior across all major workflows in the Montage web-application.

**Covered in this PR**
- Login page – Valid and invalid login flows
- Campaign page – Viewing campaign details, creating or editing campaigns
- Rounds in Campaign – Core functionality to ensure campaign rounds can be created ,updated and removed through the UI

**Important Notes:**
- Since the developer authentication bypass could not be implemented, after discussing with @Jayprakash-SE, it was decided to temporarily set up a cookie to bypass authentication for testing purposes. A `clastic_cookie` has been added for this, ensuring that the main pages can be tested with proper authentication in place. This cookie must be set before running the tests; otherwise, the entire flow will fail due to missing auth validation.
- clastic_cookie example format `token/<token>?userid=<userid>&username=<username>`

### Related issues
- Closes #304 