### PR TITLE
Feat: Add edit page warning

### DIFF
--- a/frontend/src/components/Vote/VoteEdit.vue
+++ b/frontend/src/components/Vote/VoteEdit.vue
@@ -183,7 +183,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch} from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import _ from 'lodash'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -216,7 +216,6 @@ import ThumbDown from 'vue-material-design-icons/ThumbDown.vue'
 import Star from 'vue-material-design-icons/Star.vue'
 import ArrowExpandAll from 'vue-material-design-icons/ArrowExpandAll.vue'
 import Heart from 'vue-material-design-icons/Heart.vue'
-import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import ArrowLeftThick from 'vue-material-design-icons/ArrowLeftThick.vue'
 
 // Hooks
@@ -422,11 +421,11 @@ watch(locale, (newLocale) => {
 })
 
 const beforeUnloadListner = (event) => {
-  if (edits.value.length){
+  if (edits.value.length) {
     event.preventDefault()
-    event.returnValue="";
+    event.returnValue = ''
   }
-};
+}
 
 onMounted(() => {
   getRoundDetails(voteId)
@@ -438,16 +437,16 @@ onMounted(() => {
 
   handleResize()
   window.addEventListener('resize', handleResize)
-  window.addEventListener('beforeunload',beforeUnloadListner)
+  window.addEventListener('beforeunload', beforeUnloadListner)
 })
 
 const gobackToRound = () => {
   router.push(`/vote/${round.value.link}`)
 }
 
-onBeforeRouteLeave((to,from,next)=> {
+onBeforeRouteLeave((to, from, next) => {
   if (edits.value.length) {
-    if (confirm("There are unsaved changes. Are you sure you want to leave?")) {
+    if (confirm('There are unsaved changes. Are you sure you want to leave?')) {
       next()
     } else {
       next(false)
@@ -461,7 +460,7 @@ onUnmounted(() => {
   if (editVoteContainer.value) {
     editVoteContainer.value.removeEventListener('scroll', handleScroll)
   }
-  window.removeEventListener('beforeunload',beforeUnloadListner)
+  window.removeEventListener('beforeunload', beforeUnloadListner)
   window.removeEventListener('resize', handleResize)
 })
 </script>

--- a/frontend/src/components/Vote/VoteEdit.vue
+++ b/frontend/src/components/Vote/VoteEdit.vue
@@ -87,7 +87,7 @@
 
       <cdx-button weight="quiet" action="default" @click="gobackToRound">
         <ArrowLeftThick />
-        <span>Back to Round</span>
+        <span>{{ $t('back-to-round') }}</span>
       </cdx-button>
     </div>
     <div class="image-grid" :class="'grid-size-' + gridSize" v-if="!isVoting('ranking')">
@@ -446,7 +446,7 @@ const gobackToRound = () => {
 
 onBeforeRouteLeave((to, from, next) => {
   if (edits.value.length) {
-    if (confirm('There are unsaved changes. Are you sure you want to leave?')) {
+    if (confirm($t('unsaved-changes-confirmation'))) {
       next()
     } else {
       next(false)

--- a/frontend/src/components/Vote/VoteEdit.vue
+++ b/frontend/src/components/Vote/VoteEdit.vue
@@ -84,6 +84,11 @@
       >
         <content-save-outline style="font-size: 6px" /> {{ $t('montage-round-save') }}
       </cdx-button>
+
+      <cdx-button weight="quiet" action="default" @click="gobackToRound">
+        <ArrowLeftThick />
+        <span>Back to Round</span>
+      </cdx-button>
     </div>
     <div class="image-grid" :class="'grid-size-' + gridSize" v-if="!isVoting('ranking')">
       <div
@@ -178,7 +183,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch} from 'vue'
 import _ from 'lodash'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -197,6 +202,10 @@ import { CdxButton, CdxSelect } from '@wikimedia/codex'
 import { VueDraggableNext as draggable } from 'vue-draggable-next'
 import ImageReviewDialog from './ImageReviewDialog.vue'
 
+//Services
+// import { EventBus } from 'vue-toastification' // Currently depricated
+import { onBeforeRouteLeave } from 'vue-router'
+
 // Icons
 import ContentSaveOutline from 'vue-material-design-icons/ContentSaveOutline.vue'
 import ImageSizeSelectActual from 'vue-material-design-icons/ImageSizeSelectActual.vue'
@@ -207,6 +216,8 @@ import ThumbDown from 'vue-material-design-icons/ThumbDown.vue'
 import Star from 'vue-material-design-icons/Star.vue'
 import ArrowExpandAll from 'vue-material-design-icons/ArrowExpandAll.vue'
 import Heart from 'vue-material-design-icons/Heart.vue'
+import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import ArrowLeftThick from 'vue-material-design-icons/ArrowLeftThick.vue'
 
 // Hooks
 const { t: $t } = useI18n()
@@ -410,6 +421,13 @@ watch(locale, (newLocale) => {
   dayjs.locale(newLocale)
 })
 
+const beforeUnloadListner = (event) => {
+  if (edits.value.length){
+    event.preventDefault()
+    event.returnValue="";
+  }
+};
+
 onMounted(() => {
   getRoundDetails(voteId)
   getPastVotes(voteId)
@@ -420,13 +438,30 @@ onMounted(() => {
 
   handleResize()
   window.addEventListener('resize', handleResize)
+  window.addEventListener('beforeunload',beforeUnloadListner)
+})
+
+const gobackToRound = () => {
+  router.push(`/vote/${round.value.link}`)
+}
+
+onBeforeRouteLeave((to,from,next)=> {
+  if (edits.value.length) {
+    if (confirm("There are unsaved changes. Are you sure you want to leave?")) {
+      next()
+    } else {
+      next(false)
+    }
+  } else {
+    next()
+  }
 })
 
 onUnmounted(() => {
   if (editVoteContainer.value) {
     editVoteContainer.value.removeEventListener('scroll', handleScroll)
   }
-
+  window.removeEventListener('beforeunload',beforeUnloadListner)
   window.removeEventListener('resize', handleResize)
 })
 </script>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -186,5 +186,7 @@
   "permission-denied-message": "You do not have the required permissions to access this page.",
   "permission-denied-home": "Go to Home",
   "montage-required-voting-deadline": "Choose a valid voting deadline",
-  "montage-required-fill-inputs": "Please fill all the boxes"
+  "montage-required-fill-inputs": "Please fill all the boxes",
+  "unsaved-changes-confirmation": "There are unsaved changes. Are you sure you want to leave?",
+  "back-to-round": "Back to round"
 }

--- a/frontend/src/i18n/qqq.json
+++ b/frontend/src/i18n/qqq.json
@@ -187,5 +187,7 @@
 	"montage-round-uploaders": "Label for the number of uploaders contributing files to a round.",
 	"permission-denied-title": "The title displayed on the Permission Denied page when the user is not authorized to access the requested page.",
 	"permission-denied-message": "A message explaining that the user does not have the required permissions to access the page.",
-	"permission-denied-home": "Text for the button that redirects the user to the home page if they are already authenticated."
+	"permission-denied-home": "Text for the button that redirects the user to the home page if they are already authenticated.",
+	"unsaved-changes-confirmation": "Message shown when the user attempts to leave a page with unsaved changes.",
+	"back-to-round": "Label for navigate back to the round page button"
 }


### PR DESCRIPTION
# Description

Fixes #137 

This PR consists of frontend changes, where it adds confirmation service for route or refresh page while a vote is being edited. I've also added an extra button to go back to the previous route to `/vote/roundId` on the header since the url under the round name felt like it was not enough and user friendly.