### PR TITLE
fix: use first version's timestamp and author in make_entry

### DIFF
--- a/montage/labs.py
+++ b/montage/labs.py
@@ -67,7 +67,12 @@ def get_files(category_name):
                           oi_timestamp,
                           oi_archive_name
                    FROM oldimage
-                   LEFT JOIN actor ON oi_actor=actor.actor_id) AS oi ON img_name=oi.oi_name
+                   LEFT JOIN actor ON oi_actor=actor.actor_id
+                   WHERE oi_timestamp = (
+                       SELECT MIN(oi_timestamp)
+                       FROM oldimage AS oi2
+                       WHERE oi2.oi_name = oldimage.oi_name)
+                   ) AS oi ON img_name=oi.oi_name
         JOIN page ON page_namespace = 6
         AND page_title = img_name
         JOIN categorylinks ON cl_from = page_id
@@ -95,7 +100,12 @@ def get_file_info(filename):
                           oi_timestamp,
                           oi_archive_name
                    FROM oldimage
-                   LEFT JOIN actor ON oi_actor=actor.actor_id) AS oi ON img_name=oi.oi_name
+                   LEFT JOIN actor ON oi_actor=actor.actor_id
+                   WHERE oi_timestamp = (
+                       SELECT MIN(oi_timestamp)
+                       FROM oldimage AS oi2
+                       WHERE oi2.oi_name = oldimage.oi_name)
+                   ) AS oi ON img_name=oi.oi_name
         WHERE img_name = %s
         GROUP BY img_name
         ORDER BY oi_timestamp ASC;

--- a/montage/loaders.py
+++ b/montage/loaders.py
@@ -60,13 +60,15 @@ def make_entry(edict):
                  'upload_user_text': edict['img_user_text']}
     if edict.get('oi_archive_name'):
         # The file has multiple versions
+        raw_entry['upload_date'] = wpts2dt(edict['img_timestamp'])
         raw_entry['flags'] = {
             'reupload': True,
             'reupload_date': wpts2dt(edict['rec_img_timestamp']),
             'reupload_user_id': edict['rec_img_user'],
             'reupload_user_text': edict['rec_img_text'],
             'archive_name': edict['oi_archive_name']}
-    raw_entry['upload_date'] = wpts2dt(edict['img_timestamp'])
+    else:
+        raw_entry['upload_date'] = wpts2dt(edict['img_timestamp'])
     raw_entry['resolution'] = width * height
     if edict.get('flags'):
         raw_entry['flags'] = edict['flags']


### PR DESCRIPTION
Fixes [#155](https://github.com/hatnote/montage/issues/155)

This PR fixes the problem of retrieving the latest version's timestamp and author for a file on Commons instead of the first version's (which is what should be used for disqualification by author and date).

The fix is in two places:

- **labs.py:** The SQL query previously joined `oldimage` without filtering, which caused MySQL to pick the latest version. It now uses `MIN(oi_timestamp)` to make sure that the oldest version is always returned, then uses `IFNULL(oi_timestamp,` `img_timestamp)` and `IFNULL(oi.actor_user, ci.actor_user)` to fall back to the current image table if no older version exists.
- **loaders.py:** `make_entry` now correctly uses `img_timestamp` and `img_user/img_user_text` (which already contain the first version's data after the SQL fix) and stores the latest version's info in the `flags ['reupload']` dictionary for reference.

I used Quarry since it runs queries from inside Wikimedia's cloud environment, where it has access to the `commonswiki_p` database on `commonswiki.labsdb.` 

<img width="947" height="471" alt="Screenshot 2026-02-20 064056" src="https://github.com/user-attachments/assets/5a902300-7668-48ab-baec-0082d731fbfb" />
<br><br>

The `img_user_text` and `img_timestamp` correctly returned the first version's author and date (for example, [Vulpes vulpes pups.jpg](Vulpes_vulpes_pups.jpg) now correctly shows Conti (2004) instead of Jonnmann (2021), while `rec_img_text` and `rec_img_timestamp` stored the latest version's info.

<img width="947" height="470" alt="Screenshot 2026-02-20 064116" src="https://github.com/user-attachments/assets/e4a1aea7-81e3-4744-bfe0-ec10ba826d89" />
<br><br>

I also tested [this image](https://commons.wikimedia.org/wiki/File:010_White-eared_bulbul_in_Keoladeo_National_Park_Photo_by_Giles_Laurent.jpg) locally:
The earliest version was on the 9th of July 2025:
<img width="578" height="313" alt="Screenshot 2026-02-22 114227" src="https://github.com/user-attachments/assets/ec991106-d38f-4c3d-b135-38a5905b1b0e" />

This reflects now:
<img width="941" height="425" alt="Screenshot 2026-02-22 114137" src="https://github.com/user-attachments/assets/9c441852-5dc9-4607-a974-a4032adca69c" />



