### PR TITLE
Fixed backend package versionconflict, and added instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ celerybeat-schedule
 
 # virtualenv
 venv/
+.venv*/
 ENV/
 
 # Logs
@@ -128,6 +129,10 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+# Claude Code and local temp files
+.claude/
+tmp/
 
 # Spyder project settings
 .spyderproject

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,11 @@
+#To install backend packages, run this command in CLI
+# > python3 -m venv venv
+# > source venv/bin/activate
+# > pip install -r requirements-dev.txt 
 -r requirements.txt
 
-tox<3.15.0
+tox<3.15.0  #tox version: 3.15.0 supports pluggy < 1, else we may face version conflict
+pluggy<1
 Fabric3
 coverage==5.0.2
 pytest==4.6.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+setuptools==57.5.0
 #To install backend packages, run this command in CLI
 # > python3 -m venv venv
 # > source venv/bin/activate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ setuptools==57.5.0
 # > pip install -r requirements-dev.txt 
 -r requirements.txt
 
+
 tox<3.15.0  #tox version: 3.15.0 supports pluggy < 1, else we may face version conflict
 pluggy<1
 Fabric3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 
-
-tox<3.15.0  #tox version: 3.15.0 supports pluggy < 1, else we may face version conflict
+tox<3.15.0  # tox 3.x requires pluggy<1; upgrade to tox 4.x to drop both pins
 pluggy<1
 Fabric3
 coverage==5.0.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
-setuptools==57.5.0
-
 -r requirements.txt
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,5 @@
 setuptools==57.5.0
-#To install backend packages, run this command in CLI
-# > python3 -m venv venv
-# > source venv/bin/activate
-# > pip install -r requirements-dev.txt 
+
 -r requirements.txt
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
   setuptools
 commands = coverage run --parallel --omit 'flycheck_*' --rcfile {toxinidir}/.tox-coveragerc -m pytest --ignore client/ --doctest-modules {envsitepackagesdir}/montage {posargs}
 
+
 # Uses default basepython otherwise reporting doesn't work on Travis where
 # Python 3.6 is only available in 3.6 jobs.
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py39,py311,coverage-report
 changedir = .tox
 deps =
   -rrequirements-dev.txt
+  setuptools
 commands = coverage run --parallel --omit 'flycheck_*' --rcfile {toxinidir}/.tox-coveragerc -m pytest --ignore client/ --doctest-modules {envsitepackagesdir}/montage {posargs}
 
 # Uses default basepython otherwise reporting doesn't work on Travis where

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = py39,py311,coverage-report
 changedir = .tox
 deps =
   -rrequirements-dev.txt
-  setuptools
 commands = coverage run --parallel --omit 'flycheck_*' --rcfile {toxinidir}/.tox-coveragerc -m pytest --ignore client/ --doctest-modules {envsitepackagesdir}/montage {posargs}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ deps =
   -rrequirements-dev.txt
 commands = coverage run --parallel --omit 'flycheck_*' --rcfile {toxinidir}/.tox-coveragerc -m pytest --ignore client/ --doctest-modules {envsitepackagesdir}/montage {posargs}
 
-
 # Uses default basepython otherwise reporting doesn't work on Travis where
 # Python 3.6 is only available in 3.6 jobs.
 [testenv:coverage-report]


### PR DESCRIPTION
I faced some errors while setting up the backend packages, especially with tox and pluggy

**- problem**
Project uses
tox 3.15.0 and supports pluggy < 1
but, pip installs the latest versions of the packages so the same this happened while installing pluggy, pip had installed the latest version of pluggy

**- Cause**
Not able to install packages and dependencies for backend

there were no proper instructions provided 
and was stuck there trying to figure-out what was the reason behind that huge, massive error. took the help of AI(ChatGPT) to understand the Error, and for troubleshooting, brainstorming, and code generation to resolve the version conflict.

**- Changes made**
<img width="1165" height="322" alt="Screenshot 2026-02-21 at 1 44 42 PM" src="https://github.com/user-attachments/assets/56c18b2a-d2c8-420e-9408-a1eb8af80a4d" />

**- Suggestions**
It would be clear if we provide instructions in README.md
(I can create a PR for that)

All the instructions and final changes is written and modified by me.