### PR TITLE
Fix ranking round error message

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -48,6 +48,9 @@ const addInterceptors = (instance) => {
       const loadingStore = useLoadingStore()
       loadingStore.setLoading(false)
 
+      const message = error.response?.data?.errors
+      if (message) error.message = message
+
       return Promise.reject(error)
     }
   )

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -604,6 +604,20 @@ def advance_round(user_dao, round_id, request_dict):
     # TODO: inherit round config from previous round?
     adv_group = coord_dao.finalize_rating_round(round_id, threshold=threshold)
 
+    if len(adv_group) > 100:
+        raise InvalidAction(
+            'There are too many entries advancing (%s). Adjust your threshold to '
+            'bring the number of advancing entries to 100 or fewer.'
+            % len(adv_group)
+        )
+
+    if len(adv_group) < 2:
+        raise InvalidAction(
+            'There are not enough entries advancing (%s). Lower your threshold to '
+            'allow at least 2 entries to advance to the ranking round.'
+            % len(adv_group)
+    )
+
     next_rnd = coord_dao.create_round(**nrp)
     source = 'round(#%s)' % round_id
     params = {'round': round_id,

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -604,10 +604,10 @@ def advance_round(user_dao, round_id, request_dict):
     # TODO: inherit round config from previous round?
     adv_group = coord_dao.finalize_rating_round(round_id, threshold=threshold)
 
-    if len(adv_group) > 100:
+    if len(adv_group) > 20:
         raise InvalidAction(
             'There are too many entries advancing (%s). Adjust your threshold to '
-            'bring the number of advancing entries to 100 or fewer.'
+            'bring the number of advancing entries to 20 or fewer.'
             % len(adv_group)
         )
 


### PR DESCRIPTION
Fixes [#373](https://github.com/hatnote/montage/issues/373) and [#363](https://github.com/hatnote/montage/issues/363)

Previously, organizers who tried to activate a ranking round with more than 100 images would initially not receive any error message. However, Jurors would not be able to submit as there is a limit of 100 entries. Also, there is a generic 400 error message when organizers preview their ranking round before all ballots are submitted. 

This has now been fixed with the following changes:

- `admin_endpoints.py:` Added two validation checks to raise an error telling the organizer to adjust their threshold to be <= 100 entries, and to adjust their threshold if fewer than 2 entries advance from the rating round.

- `src/services/api.js:` Updated the Axios response interceptor in `api.js` to extract the `errors` field from the backend response and set it as the error message before rejecting the promise.

<img width="932" height="435" alt="Screenshot 2026-02-22 095711" src="https://github.com/user-attachments/assets/8cd27b93-0fcd-4251-914b-eba8e1852525" />