### PR TITLE
Fix vote later permanently hiding skipped images in voting rounds

### DIFF
--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -486,8 +486,9 @@ class RoundJuror(Base):
 
     @property
     def skip(self):
-        skip = self.flags.get('skip')
-        return skip
+        if not self.flags:
+            return []
+        return self.flags.get('skipped', [])
 
     def get_count_map(self):
         rdb_session = inspect(self).session

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -957,3 +957,89 @@ def submit_ratings(client, round_id, coord_user='Yarl'):
     # get all the jurors that have open tasks in a round
     # get juror's tasks
     # submit random valid votes until there are no more tasks
+
+def test_vote_later_reappears(api_client):
+    """
+    Regression test for #371 / #372: skipped tasks should reappear after
+    the juror exhausts all remaining non-skipped tasks.
+    """
+    fetch = api_client.fetch
+
+    fetch('maintainer: add organizer',
+          '/admin/add_organizer',
+          {'username': 'Yarl'})
+
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    resp = fetch('organizer: create campaign',
+                 '/admin/add_campaign',
+                 {'name': 'Vote Later Repro',
+                  'coordinators': [u'LilyOfTheWest',
+                                   u'Slaporte',
+                                   u'Yarl'],
+                  'open_date': '2015-09-01 17:00:00',
+                  'close_date': '2015-10-01 17:00:00',
+                  'url': 'http://hatnote.com',
+                  'series_id': series_id},
+                 as_user='Yarl')
+
+    resp = fetch('coordinator: get admin view', '/admin', as_user='LilyOfTheWest')
+    campaign_id = resp['data'][-1]['id']
+
+    resp = fetch('coordinator: add yesno round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 {'name': 'Vote Later Test Round',
+                  'vote_method': 'yesno',
+                  'quorum': 1,
+                  'deadline_date': '2025-10-20T00:00:00',
+                  'jurors': [u'Slaporte']},
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    fetch('coordinator: import entries',
+          '/admin/round/%s/import' % round_id,
+          {'import_method': 'category',
+           'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+          as_user='LilyOfTheWest')
+
+    fetch('coordinator: activate round',
+          '/admin/round/%s/activate' % round_id,
+          {'post': True}, as_user='LilyOfTheWest')
+
+    resp = fetch('juror: get tasks', '/juror/round/%s/tasks' % round_id,
+                 as_user='Slaporte')
+    all_tasks = resp['data']['tasks']
+    assert len(all_tasks) >= 2, 'need at least 2 tasks to test skip'
+
+    skip_vote_id = all_tasks[0]['id']
+    fetch('juror: skip first task',
+          '/juror/round/%s/tasks/skip' % round_id,
+          {'vote_id': skip_vote_id},
+          as_user='Slaporte')
+
+    for _ in range(100):
+        resp = fetch('juror: get remaining tasks',
+                     '/juror/round/%s/tasks' % round_id,
+                     as_user='Slaporte')
+        remaining = resp['data']['tasks']
+        if not remaining:
+            break
+        if any(t['id'] == skip_vote_id for t in remaining):
+            break
+        for task in remaining:
+            fetch('juror: vote on task',
+                  '/juror/round/%s/tasks/submit' % round_id,
+                  {'ratings': [{'vote_id': task['id'], 'value': 1}]},
+                  as_user='Slaporte')
+
+    resp = fetch('juror: get tasks after voting all others',
+                 '/juror/round/%s/tasks' % round_id,
+                 as_user='Slaporte')
+    final_task_ids = [t['id'] for t in resp['data']['tasks']]
+
+    assert skip_vote_id in final_task_ids, (
+        'BUG #371: skipped task (vote_id=%s) never reappeared. '
+        'Tasks returned: %r' % (skip_vote_id, final_task_ids)
+    )
+    


### PR DESCRIPTION
Fixes [#371](https://github.com/hatnote/montage/issues/371) and [#372 ](https://github.com/hatnote/montage/issues/372)

This PR fixes the "Vote Later" bug that hid images permanently from being attended to later in the yes/no and rating rounds. It showed "all done" on the Juror's end when it was not actually complete, and less than 100% on the organizer's end, which led to not being able to finalize the round. 

This has now been fixed with the following changes:

* `montage/rdb.py:` I updated `skip_voting` to store the skipped vote IDs as a list instead of a single value, so multiple images can be skipped without replacing each other.
* `montage/rdb.py:` I updated the `get_tasks_from_round` to show the non-skipped tasks first, and only return skipped tasks when all other tasks are complete, so the skipped images are always re-queued for the juror to vote on later.
* `montage/rdb.py:` I fixed the `skip` property on `RoundJuror` to read from the new `flags['skipped']` key instead of the old `flags['skip']` key.

## Note on data migration
Any jurors who used "Vote Later" before this fix have `flags = {'skip': <vote_id>}` in the database (old format). The new code ignores that key, so their previously skipped images will show again, which is the correct behavior. There will be no data loss and no error risk.

Before:
<img width="935" height="257" alt="Screenshot 2026-02-22 131207" src="https://github.com/user-attachments/assets/668a3269-982d-4936-adcc-a657beeb4600" />
<img width="870" height="362" alt="Screenshot 2026-02-22 131142" src="https://github.com/user-attachments/assets/dcbef23e-fd17-4e43-951a-a6335f0210d6" />

After:
<img width="856" height="323" alt="Screenshot 2026-02-22 132705" src="https://github.com/user-attachments/assets/c5917481-6723-4e87-bc2a-c2d77f581e0b" />