### PR TITLE
fix: Round data invalid reloader on round deletion

### DIFF
--- a/frontend/src/components/Round/RoundEdit.vue
+++ b/frontend/src/components/Round/RoundEdit.vue
@@ -178,7 +178,7 @@ const deleteRound = () => {
         .cancelRound(props.round.id)
         .then(() => {
           emit('update:isRoundEditing', false)
-          router.reload()
+          window.location.reload()
         })
         .catch(alertService.error)
     },


### PR DESCRIPTION
# Description
Fixes #379 
Vue js uses SPA routing for navigation, and currently we were using `router.reload()` which does not exists. This PR fixes it with a relevant data reload instead of web page reload.