### PR TITLE
feat: add front and back arrow to navigate through images in yes/no and rating rounds

### DIFF
--- a/frontend/src/components/Vote/VoteRating.vue
+++ b/frontend/src/components/Vote/VoteRating.vue
@@ -16,6 +16,22 @@
         @error="handleImageLoad"
       />
       <cdx-button
+        weight="quiet"
+        class="vote-nav-prev"
+        @click="goPrev"
+        v-if="rating.currentIndex > 0"
+      >
+        <arrow-left-thick class="icon-small" />
+      </cdx-button>
+      <cdx-button
+        weight="quiet"
+        class="vote-nav-next"
+        @click="goNext"
+        v-if="votedIds.has(rating.current.id) && rating.currentIndex < images.length - 1"
+      >
+        <arrow-right-thick class="icon-small" />
+      </cdx-button>
+      <cdx-button
         @click="toggleSidebar"
         v-tooltip="$t(showSidebar ? 'montage-vote-hide-panel' : 'montage-vote-show-panel')"
         weight="quiet"
@@ -57,8 +73,12 @@
         <clip-loader v-if="isLoading" color="#36D7B7" size="20px" />
         <div v-else class="vote-controls-button">
           <span v-for="rate in [1, 2, 3, 4, 5]" :key="rate">
-            <cdx-button weight="quiet" @click="setRate(rate)">
-              <star />
+            <cdx-button 
+              :weight="currentVote === rate ? 'normal' : 'quiet'" 
+              :action="currentVote === rate ? 'progressive' : 'default'"
+              @click="setRate(rate)"
+            >
+              <star :class="currentVote === rate ? 'star-selected' : ''" />
             </cdx-button>
           </span>
         </div>
@@ -197,6 +217,7 @@ const voteContainer = ref(null);
 const showSidebar = ref(true)
 const imageCache = new Map()
 const isLoading = ref(false)
+const votedIds = ref(new Map())
 
 const props = defineProps({
   round: Object,
@@ -215,12 +236,32 @@ const rating = ref({
   rates: [1, 2, 3, 4, 5]
 })
 
+const currentVote = computed(() => {
+  if (!rating.value.current) return null
+  const val = votedIds.value.get(rating.value.current.id)
+  return val !== undefined ? val : null
+})
+
 function toggleSidebar() {
   showSidebar.value = !showSidebar.value
 }
 
 function goPrevVoteEditing() {
   router.push({ name: 'vote-edit', params: { id: roundLink } })
+}
+
+function goPrev() {
+  if (rating.value.currentIndex > 0) {
+    rating.value.currentIndex -= 1
+    rating.value.current = images.value[rating.value.currentIndex]
+  }
+}
+
+function goNext() {
+  if (rating.value.currentIndex < images.value.length - 1) {
+    rating.value.currentIndex += 1
+    rating.value.current = images.value[rating.value.currentIndex]
+  }
 }
 
 function handleImageLoad() {
@@ -272,6 +313,7 @@ function setRate(rate) {
         ratings: [{ task_id: rating.value.current.id, value: val }] 
       })
       .then(() => {
+        votedIds.value.set(rating.value.current.id, rate)
         stats.value.total_open_tasks -= 1
         if (stats.value.total_open_tasks <= 10) {
           skips.value = 0
@@ -494,8 +536,30 @@ watch( voteContainer, () => {
   margin-top: 20px;
 }
 
+.star-selected {
+  color: #3cb371;
+}
+
 .vote-commons-button {
   color: rgb(51, 102, 204);
+}
+
+.vote-nav-prev,
+.vote-nav-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 50%;
+}
+
+.vote-nav-prev {
+  left: 10px;
+}
+
+.vote-nav-next {
+  right: 40px;
 }
 
 .vote-section-title {

--- a/frontend/src/components/Vote/VoteYesNo.vue
+++ b/frontend/src/components/Vote/VoteYesNo.vue
@@ -16,6 +16,22 @@
         @error="handleImageLoad"
       />
       <cdx-button
+        weight="quiet"
+        class="vote-nav-prev"
+        @click="goPrev"
+        v-if="rating.currentIndex > 0"
+      >
+        <arrow-left-thick class="icon-small" />
+      </cdx-button>
+      <cdx-button
+        weight="quiet"
+        class="vote-nav-next"
+        @click="goNext"
+        v-if="votedIds.has(rating.current.id) && rating.currentIndex < images.length - 1"
+      >
+        <arrow-right-thick class="icon-small" />
+      </cdx-button>
+      <cdx-button
         @click="toggleSidebar"
         v-tooltip="$t(showSidebar ? 'montage-vote-hide-panel' : 'montage-vote-show-panel')"
         weight="quiet"
@@ -56,10 +72,18 @@
       <div class="vote-controls">
         <clip-loader v-if="isLoading" color="#36D7B7" size="20px" />
         <div v-else class="vote-controls-button">
-          <cdx-button action="progressive" weight="quiet" @click="setRate(5)">
+          <cdx-button 
+            action="progressive" 
+            :weight="currentVote === 5 ? 'normal' : 'quiet'" 
+            @click="setRate(5)"
+          >
             <thumb-up class="icon-small" /> {{ $t('montage-vote-accept') }}
           </cdx-button>
-          <cdx-button action="destructive" weight="quiet" @click="setRate(1)">
+          <cdx-button 
+            action="destructive" 
+            :weight="currentVote === 1 ? 'normal' : 'quiet'" 
+            @click="setRate(1)"
+          >
             <thumb-down class="icon-small" /> {{ $t('montage-vote-decline') }}
           </cdx-button>
         </div>
@@ -207,6 +231,7 @@ const props = defineProps({
 const roundLink = [props.round.id, props.round.canonical_url_name].join('-')
 
 const isLoading = ref(false)
+const votedIds = ref(new Map())
 const images = ref(null)
 const stats = ref(null)
 
@@ -217,12 +242,32 @@ const rating = ref({
   rates: [1, 2, 3, 4, 5]
 })
 
+const currentVote = computed(() => {
+  if (!rating.value.current) return null
+  const val = votedIds.value.get(rating.value.current.id)
+  return val !== undefined ? val : null
+})
+
 const toggleSidebar = () => {
   showSidebar.value = !showSidebar.value
 }
 
 const goPrevVoteEditing = () => {
   router.push({ name: 'vote-edit', params: { id: roundLink } })
+}
+
+function goPrev() {
+  if (rating.value.currentIndex > 0) {
+    rating.value.currentIndex -= 1
+    rating.value.current = images.value[rating.value.currentIndex]
+  }
+}
+
+function goNext() {
+  if (rating.value.currentIndex < images.value.length - 1) {
+    rating.value.currentIndex += 1
+    rating.value.current = images.value[rating.value.currentIndex]
+  }
 }
 
 const handleImageLoad = () => {
@@ -274,6 +319,7 @@ function setRate(rate) {
         ratings: [{ task_id: rating.value.current.id, value: val }] 
       })
       .then(() => {
+        votedIds.value.set(rating.value.current.id, rate)
         stats.value.total_open_tasks -= 1
         if (stats.value.total_open_tasks <= 10) {
           skips.value = 0
@@ -500,6 +546,24 @@ watch( voteContainer, () => {
 
 .vote-commons-button {
   color: rgb(51, 102, 204);
+}
+
+.vote-nav-prev,
+.vote-nav-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 50%;
+}
+
+.vote-nav-prev {
+  left: 10px;
+}
+
+.vote-nav-next {
+  right: 40px;
 }
 
 .vote-section-title {


### PR DESCRIPTION
Fixes [#220](https://github.com/hatnote/montage/issues/220)

**What changed:**
- Added previous/next navigation arrows overlaid on the image in yes/no and ranking rounds
- Next arrow only appears after the current image has been voted on
- Previous arrow appears from the second image onwards, which allows free backwards navigation
- The Vote state (Accept/Decline) is remembered and visually highlighted when going back to a previously voted image

**How it works:**
- `votedIds` Map tracks voted image IDs and their vote value
- `currentVote` computed shows the stored vote for the currently displayed image
- `goPrev` / `goNext` navigate through the local image batch without triggering votes or skips
- Vote buttons use `:weight="normal"` when the image has been previously voted on, which makes the selection visually clear
<img width="940" height="359" alt="Screenshot 2026-02-26 235802" src="https://github.com/user-attachments/assets/753a08ae-f622-423d-ac1d-1c906616c7cd" />
<img width="920" height="355" alt="Screenshot 2026-02-26 235822" src="https://github.com/user-attachments/assets/1ca0768e-adf0-4b06-9f63-b0fdf68c7059" />
<img width="931" height="358" alt="Screenshot 2026-02-26 235848" src="https://github.com/user-attachments/assets/dd938ce1-e0d7-4a6b-91f6-41645a2b7a12" />


