### PR TITLE
Fix: ranking round threshold validation

### DIFF
--- a/frontend/src/components/Round/RoundEdit.vue
+++ b/frontend/src/components/Round/RoundEdit.vue
@@ -100,9 +100,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
 import alertService from '@/services/alertService'
 import adminService from '@/services/adminService'
 import dialogService from '@/services/dialogService'
-import { useRouter } from 'vue-router'
 
-const router = useRouter()
 const { t: $t } = useI18n()
 const props = defineProps({
   round: Object,

--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -361,6 +361,12 @@ const submitRound = () => {
       alertService.error($t('montage-something-went-wrong'))
       return
     }
+    if (thresholds.value && !formData.value.threshold) {
+      alertService.error({
+        message: $t('montage-required-threshold')
+      })
+      return
+    }
 
     const payload = {
       next_round: {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -187,6 +187,7 @@
   "permission-denied-home": "Go to Home",
   "montage-required-voting-deadline": "Choose a valid voting deadline",
   "montage-required-fill-inputs": "Please fill all the boxes",
+  "montage-required-threshold": "Please select a threshold before continuing",
   "unsaved-changes-confirmation": "There are unsaved changes. Are you sure you want to leave?",
   "back-to-round": "Back to round"
 }

--- a/frontend/src/i18n/qqq.json
+++ b/frontend/src/i18n/qqq.json
@@ -127,6 +127,7 @@
 	"montage-round-no-category": "Message displayed when no categories are found.",
 	"montage-round-file-url": "Label for the file URL input field.",
 	"montage-round-file-list": "Label for the file list input field.",
+	"montage-required-threshold": "Error shown when the user tries to advance a round without selecting a threshold percentage.",
 	"montage-round-threshold": "Label for the threshold setting in a round.",
 	"montage-round-vote-method": "Label for the vote method setting in a round.",
 	"montage-round-threshold-description": "Description for the threshold setting, explaining its purpose.",


### PR DESCRIPTION
Fixes [#383](https://github.com/hatnote/montage/issues/383)
**What changed:**

- Added validation to prevent submitting a ranking round without selecting a threshold
- Added montage-required-threshold `i18n` key for the error message

**Before:**
<img width="863" height="125" alt="Screenshot 2026-02-27 004119" src="https://github.com/user-attachments/assets/c5d459ec-6e95-4537-9ed8-10c2746a7c85" />
<br></br>

**After:**
<img width="932" height="437" alt="threshold" src="https://github.com/user-attachments/assets/3af0b745-ab8b-40c6-97ef-a3e16a5dcc7f" />
