### PR TITLE
feat: add image resolution controller in create new round

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -115,8 +115,16 @@
                 </cdx-checkbox>
               </cdx-field>
               <cdx-field v-if="formData.config.dq_by_resolution">
-                <cdx-text-input v-model="formData.config.min_resolution" input-type="number" />
+                <cdx-text-input 
+                  v-model="formData.config.min_resolution" 
+                  input-type="number"
+                  :min="100000"
+                  :step="100000"
+                  placeholder="2000000" />
                 <template #label>{{ $t('montage-round-min-resolution') }}</template>
+                <template #help-text>
+                  <p>{{ $t('montage-round-min-resolution-help') }}</p>
+                </template>
               </cdx-field>
             </div>
           </div>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -91,6 +91,7 @@
   "montage-round-dq-organizers": "Disqualify organizers",
   "montage-round-final-threshold": "Final threshold",
   "montage-round-min-resolution": "Min. resolution",
+  "montage-round-min-resolution-help": "Minimum image resolution in pixels. Images below this resolution will be automatically disqualified. Default is 2,000,000 pixels (2 megapixels).",
   "montage-round-show-filename": "Show filename",
   "montage-round-show-link": "Show link",
   "montage-round-show-resolution": "Show resolution",


### PR DESCRIPTION
# Description
Fixes #289 and Fixes #323 
According to these issues the major concern was the inability to update certain parameters on round creation notably, `min_resolution` and `file_type`. I've checked both frontend and backend files for this and came with this conclusion.

The backend is perfectly fine as `DEFAULT_ROUND_CONFIG` is being updated on `create_round` function and it includes all the parameters including `min_resolution`. So the backend is fine. The only change we need to add was in `RoundNew` file and that's what I did.

This is how new round looks like:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0d4478ab-dd51-41f5-a427-80aba159ce98" />

<img width="1833" height="690" alt="image" src="https://github.com/user-attachments/assets/9e3e5aa8-cd1e-4fa2-9006-728c94e4f379" />


Database log for `min_resolution`
<img width="1858" height="79" alt="image" src="https://github.com/user-attachments/assets/9054a079-0034-43b0-ab5e-cfa319b1ac07" />
