### PR TITLE
Add campaign-scoped favorites for jurors

### DIFF
--- a/frontend/src/components/Campaign/JurorCampaignCard.vue
+++ b/frontend/src/components/Campaign/JurorCampaignCard.vue
@@ -54,12 +54,20 @@
         </cdx-card>
       </div>
     </div>
+    <div class="faves-button-row">
+      <cdx-button action="progressive" @click="goFaves()" style="font-size: 14px;">
+        <span class="faves-button-content">
+        {{ $t('montage-my-campaign-faves') }}<heart style=" font-size: 4px" />
+        </span>
+      </cdx-button>
+    </div>
   </cdx-accordion>
 </template>
 
 <script setup>
 import { useRouter } from 'vue-router'
 import { getVotingName } from '@/utils'
+import Heart from 'vue-material-design-icons/Heart.vue'
 
 // Components
 import { CdxCard, CdxAccordion, CdxButton } from '@wikimedia/codex'
@@ -69,7 +77,7 @@ import ThumbsUpDown from 'vue-material-design-icons/ThumbsUpDown.vue'
 import StarOutline from 'vue-material-design-icons/StarOutline.vue'
 import Sort from 'vue-material-design-icons/Sort.vue'
 
-defineProps({
+const props = defineProps({
   campaign: Object
 })
 
@@ -77,6 +85,11 @@ const router = useRouter()
 
 const goRoundVoting = (round, type) => {
   router.push({ name: type, params: { id: [round.id, round.canonical_url_name].join('-') } })
+}
+
+const goFaves = () => {
+  const round = props.campaign[0]
+  router.push({ name: 'faves', params: { id: [round.id, round.canonical_url_name].join('-') } })
 }
 </script>
 
@@ -90,6 +103,18 @@ const goRoundVoting = (round, type) => {
   display: flex;
   flex-direction: column;
   margin-bottom: 24px;
+}
+
+.faves-button-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.faves-button-content {
+  display: flex;
+  align-items: center;
+  gap: 3px;
 }
 
 .round-header {

--- a/frontend/src/components/Vote/Faves.vue
+++ b/frontend/src/components/Vote/Faves.vue
@@ -1,0 +1,297 @@
+<template>
+  <!-- Loading state -->
+  <div v-if="!round || !faves" class="loading-container">
+    <clip-loader class="loading-bar" size="85px" />
+  </div>
+
+  <!-- Main faves screen -->
+  <div v-else-if="round.campaign.status === 'active' && faves.length" class="edit-vote-screen" @scroll="handleScroll"
+    ref="favesContainer">
+    <div class="round-header">
+      <div>
+        <h2 v-html="$t('montage-faves-for', [`<a href='#/vote/${round.link}'>${round.name}</a>`])"></h2>
+        <p style="color: gray">
+          {{ $t('montage-vote-round-part-of-campaign', [round.campaign.name]) }}
+        </p>
+      </div>
+      <div class="grid-size-controls" style="margin-left: 60px">
+        <p style="font-size: 16px; color: gray; margin-left: 11px">
+          {{ $t('montage-vote-gallery-size') }}
+        </p>
+        <cdx-button :action="gridSize === 3 ? 'progressive' : ''" weight="quiet" @click="setGridSize(3)">
+          <image-size-select-actual style="font-size: 6px" />
+          {{ $t('montage-vote-grid-size-large') }}
+        </cdx-button>
+        <cdx-button :action="gridSize === 2 ? 'progressive' : ''" weight="quiet" @click="setGridSize(2)">
+          <image-size-select-large style="font-size: 6px" />
+          {{ $t('montage-vote-grid-size-medium') }}
+        </cdx-button>
+        <cdx-button :action="gridSize === 1 ? 'progressive' : ''" weight="quiet" @click="setGridSize(1)">
+          <image-size-select-small style="font-size: 6px" />
+          {{ $t('montage-vote-grid-size-small') }}
+        </cdx-button>
+      </div>
+    </div>
+
+    <div class="image-grid" :class="'grid-size-' + gridSize">
+      <div v-for="image in faves" :key="image.id" class="gallery-image link" :class="getImageSizeClass()">
+        <div class="gallery-image-fav">
+          <heart style="color: red" />
+        </div>
+        <div class="gallery-image-container">
+          <CommonsImage :image="image" :width="640" />
+        </div>
+        <div style="font-size: 14px; color: gray">
+          <p>{{ $t('montage-voted-time', [dayjs.utc(image.fave_date).fromNow()]) }}</p>
+          <p>{{ dayjs.utc(image.fave_date).format('D MMM YYYY [at] H:mm [UTC]') }}</p>
+        </div>
+        <div class="image-grid-vote-action">
+          <cdx-button weight="quiet" action="destructive" @click="removeFave(image)">
+            <heart-off class="icon-small" /> {{ $t('montage-vote-remove-favorites') }}
+          </cdx-button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- No faves yet -->
+  <div v-else-if="round && faves && !faves.length" class="no-faves">
+    <div>
+      <heart style="font-size: 48px; color: #ccc" />
+      <h3>{{ $t('montage-no-faves-yet') }}</h3>
+      <p class="greyed">{{ $t('montage-no-faves-this-round') }}</p>
+      <cdx-button action="progressive" @click="goVoting" style="margin-top: 10px">
+        {{ $t('montage-vote') }}
+      </cdx-button>
+    </div>
+  </div>
+
+  <!-- Round not active -->
+  <div v-else>
+    <h3>{{ $t('montage-vote-round-inactive') }}</h3>
+    <p class="greyed">{{ $t('montage-vote-contact-organizer') }}</p>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+import _ from 'lodash'
+import { useRouter, useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import dayjs from 'dayjs'
+import 'dayjs/locale/en'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import utc from 'dayjs/plugin/utc'
+import jurorService from '@/services/jurorService'
+import alertService from '@/services/alertService'
+import CommonsImage from '@/components/CommonsImage.vue'
+
+// Components
+import { CdxButton } from '@wikimedia/codex'
+
+// Icons
+import ImageSizeSelectActual from 'vue-material-design-icons/ImageSizeSelectActual.vue'
+import ImageSizeSelectLarge from 'vue-material-design-icons/ImageSizeSelectLarge.vue'
+import ImageSizeSelectSmall from 'vue-material-design-icons/ImageSizeSelectSmall.vue'
+import Heart from 'vue-material-design-icons/Heart.vue'
+import HeartOff from 'vue-material-design-icons/HeartOff.vue'
+
+// Hooks
+const { t: $t } = useI18n()
+const router = useRouter()
+const route = useRoute()
+const { locale } = useI18n()
+
+const voteId = route.params.id.split('-')[0]
+dayjs.extend(relativeTime)
+dayjs.extend(utc)
+dayjs.locale(locale.value)
+
+const round = ref(null)
+const faves = ref(null)
+const loadingMore = ref(false)
+const favesContainer = ref(null)
+const gridSize = ref(1)
+
+const setGridSize = (size) => {
+  gridSize.value = size
+}
+
+const getImageSizeClass = () => {
+  return `gallery-image--size-${gridSize.value}`
+}
+
+const goVoting = () => {
+  router.push({ name: 'vote', params: { id: route.params.id } })
+}
+
+function getRoundDetails(id) {
+  jurorService
+    .getRound(id)
+    .then((response) => {
+      const r = response.data
+      round.value = r
+      round.value.link = [r.id, r.canonical_url_name].join('-')
+      return getFaves()
+    })
+    .then((data) => {
+      if (data) faves.value = data
+    })
+    .catch(alertService.error)
+}
+
+function getFaves(offset = 0) {
+  return jurorService
+    .getFaves(round.value.campaign.id, offset)
+    .then((response) => {
+      return response.data
+    })
+    .catch(alertService.error)
+}
+
+const removeFave = (image) => {
+  jurorService
+    .unfaveImage(round.value.id, image.id)
+    .then(() => {
+      faves.value = faves.value.filter((f) => f.id !== image.id)
+      alertService.success($t('montage-vote-removed-favorites'), 500)
+    })
+    .catch(alertService.error)
+}
+
+const loadMore = () => {
+  if (loadingMore.value) return
+  loadingMore.value = true
+  return getFaves(faves.value.length)
+    .then((newFaves) => {
+      if (newFaves?.length) {
+        faves.value.push(...newFaves)
+      }
+    })
+    .finally(() => {
+      loadingMore.value = false
+    })
+}
+
+const handleScroll = _.throttle(() => {
+  if (!favesContainer.value) return
+  if (loadingMore.value) return
+
+  const container = favesContainer.value
+  const { scrollTop, scrollHeight, clientHeight } = container
+  const triggerPoint = scrollHeight - clientHeight
+
+  if (scrollTop >= triggerPoint) {
+    loadMore()
+  }
+}, 500)
+
+const handleResize = () => {
+  const width = window.innerWidth
+  if (width < 800) {
+    setGridSize(3)
+  } else if (width >= 800 && width <= 1150) {
+    setGridSize(2)
+  } else {
+    setGridSize(1)
+  }
+}
+
+watch(locale, (newLocale) => {
+  dayjs.locale(newLocale)
+})
+
+onMounted(() => {
+  getRoundDetails(voteId)
+  handleResize()
+  window.addEventListener('resize', handleResize)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize)
+})
+</script>
+
+<style scoped>
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 156.5px);
+  width: 100%;
+}
+
+.edit-vote-screen {
+  padding: 20px;
+  overflow-y: auto;
+  max-height: 80vh;
+}
+
+.round-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.image-grid {
+  margin-top: 8px;
+}
+
+.image-grid-vote-action {
+  margin-bottom: 40px;
+  display: flex;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.gallery-image {
+  display: inline-block;
+  position: relative;
+  background: #ccc;
+  width: calc((100% - 100px) / 5);
+  height: 15vw;
+  margin: 10px 10px 100px;
+  vertical-align: top;
+}
+
+.gallery-image-fav {
+  position: absolute;
+  right: 0;
+  color: red;
+  z-index: 1;
+}
+
+.gallery-image--size-2 {
+  width: calc((100% - 100px) / 3);
+  height: 28vw;
+}
+
+.gallery-image--size-3 {
+  width: calc((100% - 100px) / 2);
+  height: 43vw;
+}
+
+.gallery-image-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.gallery-image-container img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.no-faves {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 156.5px);
+  text-align: center;
+}
+</style>

--- a/frontend/src/components/Vote/VoteRanking.vue
+++ b/frontend/src/components/Vote/VoteRanking.vue
@@ -64,10 +64,16 @@
       <h3>{{ $t('montage-vote-all-done') }}</h3>
       <p class="greyed">{{ $t('montage-vote-no-images') }}</p>
       <p class="greyed">{{ $t('montage-vote-no-images-warning') }}</p>
-      <cdx-button class="edit-voting-btn" @click="editPreviousVotes">
-        <pencil class="icon-small" />
-        {{ $t('montage-edit-previous-vote') }}
-      </cdx-button>
+      <div class="voting-completed-actions">
+        <cdx-button class="edit-voting-btn" @click="editPreviousVotes">
+          <pencil class="icon-small" />
+          {{ $t('montage-edit-previous-vote') }}
+        </cdx-button>
+        <cdx-button class="edit-voting-btn" @click="goFaves">
+          <heart class="icon-small" />
+          {{ $t('montage-my-campaign-faves') }}
+        </cdx-button>
+      </div>
     </div>
   </div>
 
@@ -91,12 +97,14 @@ import CommonsImage from '@/components/CommonsImage.vue'
 import { VueDraggableNext as draggable } from 'vue-draggable-next'
 import { CdxButton } from '@wikimedia/codex'
 
-// Icon
+// Icons
 import ContentSaveOutline from 'vue-material-design-icons/ContentSaveOutline.vue'
 import ImageSizeSelectActual from 'vue-material-design-icons/ImageSizeSelectActual.vue'
 import ImageSizeSelectLarge from 'vue-material-design-icons/ImageSizeSelectLarge.vue'
 import ImageSizeSelectSmall from 'vue-material-design-icons/ImageSizeSelectSmall.vue'
 import ArrowExpandAll from 'vue-material-design-icons/ArrowExpandAll.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import Heart from 'vue-material-design-icons/Heart.vue'
 import ImageReviewDialog from './ImageReviewDialog.vue'
 
 const { t: $t } = useI18n()
@@ -165,6 +173,10 @@ const saveRanking = () => {
 
 const editPreviousVotes = () => {
   router.push({ name: 'vote-edit', params: { id: roundLink } })
+}
+
+const goFaves = () => {
+  router.push({ name: 'faves', params: { id: roundLink } })
 }
 
 watch(
@@ -301,8 +313,13 @@ watch(
   align-items: center;
 }
 
-.edit-voting-btn {
+.voting-completed-actions {
+  display: flex;
+  gap: 12px;
   margin-top: 24px;
+}
+
+.edit-voting-btn {
   width: 232px;
 }
 </style>

--- a/frontend/src/components/Vote/VoteRating.vue
+++ b/frontend/src/components/Vote/VoteRating.vue
@@ -92,6 +92,11 @@
             <pencil class="icon-small" /> {{ $t('montage-edit-previous-vote') }}
           </cdx-button>
         </div>
+        <div>
+          <cdx-button weight="quiet" @click="goFaves()">
+            <heart class="icon-small" /> {{ $t('montage-my-campaign-faves') }}
+          </cdx-button>
+        </div>
       </div>
 
       <h3 class="vote-section-title">{{ $t('montage-vote-description') }}</h3>
@@ -150,10 +155,16 @@
       <p class="greyed">
         {{ $t('montage-vote-no-images-warning') }}
       </p>
-      <cdx-button class="edit-voting-btn" @click="goPrevVoteEditing">
-        <pencil class="icon-small" />
-        {{ $t('montage-edit-previous-vote') }}
-      </cdx-button>
+      <div class="voting-completed-actions">
+        <cdx-button class="edit-voting-btn" @click="goPrevVoteEditing">
+          <pencil class="icon-small" />
+          {{ $t('montage-edit-previous-vote') }}
+        </cdx-button>
+        <cdx-button class="edit-voting-btn" @click="goFaves()">
+          <heart class="icon-small" />
+          {{ $t('montage-my-campaign-faves') }}
+        </cdx-button>
+      </div>
     </div>
   </div>
   <div v-if="round.status !== 'active'">
@@ -221,6 +232,10 @@ function toggleSidebar() {
 
 function goPrevVoteEditing() {
   router.push({ name: 'vote-edit', params: { id: roundLink } })
+}
+
+const goFaves = () => {
+  router.push({ name: 'faves', params: { id: roundLink } })
 }
 
 function handleImageLoad() {
@@ -599,8 +614,13 @@ watch( voteContainer, () => {
   align-items: center;
 }
 
-.edit-voting-btn {
+.voting-completed-actions {
+  display: flex;
+  gap: 12px;
   margin-top: 24px;
+}
+
+.edit-voting-btn {
   width: 232px;
 }
 </style>

--- a/frontend/src/components/Vote/VoteYesNo.vue
+++ b/frontend/src/components/Vote/VoteYesNo.vue
@@ -93,6 +93,11 @@
             <pencil class="icon-small" /> {{ $t('montage-edit-previous-vote') }}
           </cdx-button>
         </div>
+        <div>
+          <cdx-button weight="quiet" @click="goFaves()">
+            <heart class="icon-small" /> {{ $t('montage-my-campaign-faves') }}
+          </cdx-button>
+        </div>
       </div>
 
       <h3 class="vote-section-title">{{ $t('montage-vote-description') }}</h3>
@@ -151,10 +156,16 @@
       <p class="greyed">
         {{ $t('montage-vote-no-images-warning') }}
       </p>
-      <cdx-button class="edit-voting-btn" @click="goPrevVoteEditing">
-        <pencil class="icon-small" />
-        {{ $t('montage-edit-previous-vote') }}
-      </cdx-button>
+      <div class="voting-completed-actions">
+        <cdx-button class="edit-voting-btn" @click="goPrevVoteEditing">
+          <pencil class="icon-small" />
+          {{ $t('montage-edit-previous-vote') }}
+        </cdx-button>
+        <cdx-button class="edit-voting-btn" @click="goFaves()">
+          <heart class="icon-small" />
+          {{ $t('montage-my-campaign-faves') }}
+        </cdx-button>
+      </div>
     </div>
   </div>
   <div v-if="round.status !== 'active'">
@@ -223,6 +234,10 @@ const toggleSidebar = () => {
 
 const goPrevVoteEditing = () => {
   router.push({ name: 'vote-edit', params: { id: roundLink } })
+}
+
+const goFaves = () => {
+  router.push({ name: 'faves', params: { id: roundLink } })
 }
 
 const handleImageLoad = () => {
@@ -603,8 +618,13 @@ watch( voteContainer, () => {
   align-items: center;
 }
 
-.edit-voting-btn {
+.voting-completed-actions {
+  display: flex;
+  gap: 12px;
   margin-top: 24px;
+}
+
+.edit-voting-btn {
   width: 232px;
 }
 </style>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -30,6 +30,7 @@
   "montage-your-progress": "Your progress",
   "montage-vote": "Vote",
   "montage-edit-previous-vote": "Edit previous votes",
+  "montage-my-campaign-faves": "View Favorites",
   "montage-progress-status": "{0} out of {1}",
   "montage-new-campaig-heading": "New campaign",
   "montage-placeholder-campaign-name": "Campaign name",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -11,6 +11,7 @@ import VoteView from '@/views/VoteView.vue'
 import VoteEditView from '@/views/VoteEditView.vue'
 import AllCampaignView from '@/views/AllCampaignView.vue'
 import PermissionDenied from '@/views/PermissionDenied.vue'
+import FavesView from '@/views/FavesView.vue'
 
 const routes = [
   {
@@ -46,6 +47,12 @@ const routes = [
     path: '/vote/:id/edit',
     name: 'vote-edit',
     component: VoteEditView,
+    meta: { requiresAuth: true }
+  },
+  {                                   
+    path: '/vote/:id/faves',
+    name: 'faves',
+    component: FavesView,
     meta: { requiresAuth: true }
   },
   {

--- a/frontend/src/services/jurorService.js
+++ b/frontend/src/services/jurorService.js
@@ -14,7 +14,7 @@ const jurorService = {
 
   getPastRanking: (id) => apiBackend.get(`juror/round/${id}/rankings`),
 
-  getFaves: () => apiBackend.get('juror/faves'),
+  getFaves: (campaignId, offset = 0) => apiBackend.get('juror/faves', { params: { campaign_id: campaignId, offset } }),
 
   getRound: (id) => apiBackend.get(`juror/round/${id}`),
 

--- a/frontend/src/views/FavesView.vue
+++ b/frontend/src/views/FavesView.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="faves-view-container">
+    <faves />
+  </div>
+</template>
+
+<script setup>
+import Faves from '@/components/Vote/Faves.vue'
+</script>
+
+<style scoped>
+.faves-view-container {
+  padding: 20px;
+}
+</style>

--- a/montage/juror_endpoints.py
+++ b/montage/juror_endpoints.py
@@ -224,12 +224,12 @@ def get_rankings_from_round(user_dao, round_id, request):
 
 def get_faves(user_dao, request_dict):
     request_dict = request_dict or dict()
-
     juror_dao = JurorDAO(user_dao)
     limit = request_dict.get('limit', 10)
     offset = request_dict.get('offset', 0)
     sort = request_dict.get('sort', 'desc')
-    faves = juror_dao.get_faves(sort, limit, offset)
+    campaign_id = request_dict.get('campaign_id')
+    faves = juror_dao.get_faves(campaign_id=campaign_id, sort=sort, limit=limit, offset=offset)
     return {'data': [f.to_details_dict() for f in faves]}
 
 

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -743,11 +743,16 @@ class Vote(Base):
 
     def check_fave(self):
         rdb_session = inspect(self).session
+        campaign_id = (rdb_session.query(Round.campaign_id)
+                        .join(RoundEntry, RoundEntry.round_id == Round.id)
+                        .filter(RoundEntry.id == self.round_entry_id)
+                        .scalar())
         # TODO: check, is this slow?
         faves = (rdb_session.query(Favorite)
                     .filter_by(entry_id=self.entry.id,
-                               user_id=self.user.id,
-                               status=ACTIVE_STATUS)
+                                user_id=self.user.id,
+                                campaign_id=campaign_id,
+                                status=ACTIVE_STATUS)
                     .all())
         return len(faves) > 0
 
@@ -2578,11 +2583,12 @@ class JurorDAO(object):
             return task_query.filter(Vote.id > skip).limit(num).all()
         
         return task_query.limit(num).all()
-
-    def get_faves(self, sort='desc', limit=10, offset=0):
+    def get_faves(self, campaign_id=None, sort='desc', limit=10, offset=0):
         faves_query = (self.query(Favorite)
                             .filter_by(user=self.user,
                                         status=ACTIVE_STATUS))
+        if campaign_id:
+            faves_query = faves_query.filter_by(campaign_id=campaign_id)
         if sort == 'asc':
             faves_query = faves_query.order_by(
                             func.coalesce(Favorite.modified_date,
@@ -2591,7 +2597,7 @@ class JurorDAO(object):
             faves_query = faves_query.order_by(
                             func.coalesce(Favorite.modified_date,
                             Favorite.create_date).desc())
-        faves = faves_query.limit(limit).offset(0).all()
+        faves = faves_query.limit(limit).offset(offset).all()
         return faves
 
     def get_ratings_from_round(self, round_id, num,
@@ -2869,32 +2875,40 @@ class JurorDAO(object):
             vote.status = COMPLETED_STATUS
             self.rdb_session.add(vote)
         return
-
+    
     def fave(self, round_id, entry_id):
+        round_entry = self.get_round_entry(round_id, entry_id)
+        campaign_id = round_entry.round.campaign.id    
+
         existing_fave = (self.query(Favorite)
                              .filter_by(entry_id=entry_id,
-                                        user=self.user)
-                             .first())  # there should be one
+                                        user=self.user,
+                                        campaign_id=campaign_id)
+                             .first())
         if existing_fave:
             existing_fave.modified_date = datetime.datetime.utcnow()
             existing_fave.status = ACTIVE_STATUS
             return
 
-        round_entry = self.get_round_entry(round_id, entry_id)
         fave = Favorite(entry_id=round_entry.entry.id,
-                       round_entry_id = round_entry.id,
-                       campaign_id=round_entry.round.campaign.id,
-                       user=self.user,
-                       status=ACTIVE_STATUS)
+                   round_entry_id=round_entry.id,
+                   campaign_id=campaign_id,
+                   user=self.user,
+                   status=ACTIVE_STATUS)
         self.rdb_session.add(fave)
 
     def unfave(self, round_id, entry_id):
+        round_entry = self.get_round_entry(round_id, entry_id)
+        campaign_id = round_entry.round.campaign.id
+
         fave = (self.query(Favorite)
-               .join(RoundEntry, RoundEntry.id == Favorite.round_entry_id)
-               .filter(Favorite.entry_id == entry_id,
+                .filter(Favorite.entry_id == entry_id,
                        Favorite.user == self.user,
-                       RoundEntry.round_id == round_id)
-               .one())
+                       Favorite.campaign_id == campaign_id,
+                       Favorite.status == ACTIVE_STATUS)
+               .one_or_none())
+        if not fave:
+            return
         fave.status = CANCELLED_STATUS
         fave.modified_date = datetime.datetime.utcnow()
 


### PR DESCRIPTION
Fixes #333 

Some Jurors have voted on a lot of pictures, and scrolling through so many to see their favorites is stressful. This PR adds a "View Favorites" button to the juror campaign card, which allows them to quickly go to their favorited images for a specific campaign.

### Changes:

**Frontend**
- `JurorCampaignCard.vue`: Added a "View Favorites" button with a heart icon that navigates to the new faves view for the campaign
- `VoteRating.vue`, `VoteYesNo.vue`, `VoteRanking.vue`: Added a "View Favorites" button alongside the existing "Edit previous votes" button in both the active voting view and the all-done state
- `router/index.js`: Added new `/vote/:id/faves` route pointing to `FavesView`
- `jurorService.js`: Updated `getFaves` to accept `campaignId` and `offset` parameters
- `en.json`: Added `montage-my-campaign-faves` i18n string ("View Favorites")

**Backend**
- `juror_endpoints.py`: Updated `get_faves` endpoint to accept and pass `campaign_id` filter
- `rdb.py`:
  - `JurorDAO.get_faves`: Added `campaign_id` filter and fixed a bug where `offset` was hardcoded to `0`
  - `JurorDAO.fave`: Fetch `round_entry` before checking for existing fave so `campaign_id` is available for scoping; fixes potential cross-campaign fave collisions
  - `JurorDAO.unfave`: Scoped unfave lookup by `campaign_id` and `status`; changed `.one()` to `.one_or_none()` to handle it incase 'fave' doesn't exist
  - `Vote.check_fave`: Added `campaign_id` lookup so fave checks are scoped to the correct campaign

<img width="907" height="363" alt="Screenshot 2026-02-27 124008" src="https://github.com/user-attachments/assets/81e54bc4-881c-4c65-bf24-8d8685756e6a" />
<img width="944" height="469" alt="yooo" src="https://github.com/user-attachments/assets/feb1c1cb-ac3d-42a8-9f65-aa22d757d216" />

**A dedicated Favorites page:**
<img width="947" height="470" alt="yooo1" src="https://github.com/user-attachments/assets/33befda8-dbc0-4298-aa6e-ad9d71a4120a" />
