### PR TITLE
Fix UI validation error where empty threshold causes network error

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -263,7 +263,8 @@ const submitRound = () => {
 
   if (
   !formData.value.name ||
-  (formData.value.quorum > 0 && formData.value.jurors.length === 0)
+  (formData.value.quorum > 0 && formData.value.jurors.length === 0) ||
+  (roundIndex !== 0 && thresholds.value && formData.value.threshold === null)
 ) {
     alertService.error({
       message: $t('montage-required-fill-inputs')


### PR DESCRIPTION
Fix: Prevent 500 error when creating ranking round without threshold

This PR implements a defense-in-depth solution for the issue where submitting a ranking round without selecting a threshold resulted in a 500 Internal Server Error.

Frontend (UX Layer)
Updated frontend/src/components/Round/RoundNew.vue to prevent form submission when the threshold dropdown is visible but no value is selected. This ensures invalid payloads are not sent to the backend.

Backend (Safety Layer)
Hardened the advance_round function in montage/admin_endpoints.py by expanding exception handling to catch TypeError (in addition to KeyError) when converting the threshold value to float. This prevents float(None) from causing an unhandled exception and instead returns a proper validation error.

This ensures that even if frontend validation is bypassed, the backend responds with a controlled 400 error instead of crashing.