### PR TITLE
feat: open edit vote in new tab while voting

### DIFF
--- a/frontend/src/components/Vote/VoteRanking.vue
+++ b/frontend/src/components/Vote/VoteRanking.vue
@@ -83,10 +83,12 @@
       <h3>{{ $t('montage-vote-all-done') }}</h3>
       <p class="greyed">{{ $t('montage-vote-no-images') }}</p>
       <p class="greyed">{{ $t('montage-vote-no-images-warning') }}</p>
-      <cdx-button class="edit-voting-btn" @click="editPreviousVotes">
-        <pencil class="icon-small" />
-        {{ $t('montage-edit-previous-vote') }}
-      </cdx-button>
+      <a :href="router.resolve({ name: 'vote-edit', params: { id: roundLink } }).href">
+        <cdx-button class="edit-voting-btn" @click="editPreviousVotes">
+          <pencil class="icon-small" />
+          {{ $t('montage-edit-previous-vote') }}
+        </cdx-button>
+      </a>
     </div>
   </div>
 

--- a/frontend/src/components/Vote/VoteRating.vue
+++ b/frontend/src/components/Vote/VoteRating.vue
@@ -88,9 +88,11 @@
           <cdx-button weight="quiet" @click="setRate()">
             <arrow-right class="icon-small" /> {{ $t('montage-vote-skip') }}
           </cdx-button>
-          <cdx-button weight="quiet" @click="goPrevVoteEditing">
-            <pencil class="icon-small" /> {{ $t('montage-edit-previous-vote') }}
-          </cdx-button>
+          <a :href="router.resolve({ name: 'vote-edit', params: { id: roundLink } }).href">
+            <cdx-button weight="quiet" @click="goPrevVoteEditing">
+              <pencil class="icon-small" /> {{ $t('montage-edit-previous-vote') }}
+            </cdx-button>
+          </a>
         </div>
       </div>
 
@@ -153,10 +155,12 @@
       <p class="greyed">
         {{ $t('montage-vote-no-images-warning') }}
       </p>
-      <cdx-button class="edit-voting-btn" @click="goPrevVoteEditing">
-        <pencil class="icon-small" />
-        {{ $t('montage-edit-previous-vote') }}
-      </cdx-button>
+      <a :href="router.resolve({ name: 'vote-edit', params: { id: roundLink } }).href">
+        <cdx-button class="edit-voting-btn" @click="goPrevVoteEditing">
+          <pencil class="icon-small" />
+          {{ $t('montage-edit-previous-vote') }}
+        </cdx-button>
+      </a>
     </div>
   </div>
   <div v-if="round.status !== 'active'">
@@ -229,6 +233,7 @@ function goPrevVoteEditing() {
 function handleImageLoad() {
   imageLoading.value = false
 }
+
 
 const formattedDate = (timestamp) => {
   if (!timestamp) return ''

--- a/frontend/src/components/Vote/VoteYesNo.vue
+++ b/frontend/src/components/Vote/VoteYesNo.vue
@@ -89,9 +89,11 @@
           <cdx-button weight="quiet" @click="setRate()">
             <arrow-right class="icon-small" /> {{ $t('montage-vote-skip') }}
           </cdx-button>
-          <cdx-button weight="quiet" @click="goPrevVoteEditing">
-            <pencil class="icon-small" /> {{ $t('montage-edit-previous-vote') }}
-          </cdx-button>
+          <a :href="router.resolve({ name: 'vote-edit', params: { id: roundLink } }).href">
+            <cdx-button weight="quiet" @click="goPrevVoteEditing">
+              <pencil class="icon-small" /> {{ $t('montage-edit-previous-vote') }}
+            </cdx-button>
+          </a>
         </div>
       </div>
 
@@ -157,10 +159,12 @@
       <p class="greyed">
         {{ $t('montage-vote-no-images-warning') }}
       </p>
-      <cdx-button class="edit-voting-btn" @click="goPrevVoteEditing">
-        <pencil class="icon-small" />
-        {{ $t('montage-edit-previous-vote') }}
-      </cdx-button>
+      <a :href="router.resolve({ name: 'vote-edit', params: { id: roundLink } }).href">
+        <cdx-button class="edit-voting-btn" @click="goPrevVoteEditing">
+          <pencil class="icon-small" />
+          {{ $t('montage-edit-previous-vote') }}
+        </cdx-button>
+      </a>
     </div>
   </div>
   <div v-if="round.status !== 'active'">
@@ -267,6 +271,7 @@ const getTasks = () => {
     }
   })
 }
+
 
 function setRate(rate) {
   if (imageLoading.value) return


### PR DESCRIPTION
Fixes #320 
This PR wraps the "edit previous vote" buttons in voting rounds (i.e., when jurors are voting) in anchor tags so jurors can right-click them to open rounds in a new tab.

**Changes**
- Wrapped round voting buttons with `<a>` tags using `router.resolve` to generate hrefs
- Added `getEditHref()` helper function to resolve vote-edit route URLs.