### PR TITLE
fix: allow closing campaign after any finalized round

### DIFF
--- a/frontend/src/components/Campaign/ViewCampaign.vue
+++ b/frontend/src/components/Campaign/ViewCampaign.vue
@@ -4,7 +4,12 @@
       <div class="campaign-header">
         <p class="campaign-title">{{ campaign.name }}</p>
         <div class="campaign-button-group">
-          <cdx-button action="destructive" weight="primary" @click="closeCampaign">
+          <cdx-button
+            v-if="canCloseCampaign"
+            action="destructive"
+            weight="primary"
+            @click="closeCampaign"
+          >
             <clipboard-check class="icon-small" /> {{ $t('montage-close-campaign') }}
           </cdx-button>
           <cdx-button action="destructive" @click="archiveCampaign" v-if="!campaign.is_archived">
@@ -326,6 +331,7 @@ const closeCampaign = () => {
     .finalizeCampaign(campaignId)
     .then((resp) => {
       if (resp.status === 'success') {
+        alertService.success('Campaign closed.')
         reloadState()
       }
     })

--- a/frontend/src/components/Round/RoundInfo.vue
+++ b/frontend/src/components/Round/RoundInfo.vue
@@ -69,7 +69,7 @@
         </p>
         <p>
           <strong>{{ $t('montage-round-cancelled-tasks') }}:</strong>
-          {{ rroundResults?.counts.total_cancelled_tasks }}
+          {{ roundResults?.counts.total_cancelled_tasks }}
         </p>
         <p>
           <strong>{{ $t('montage-round-disqualified-files') }}:</strong>

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -628,18 +628,22 @@ def advance_round(user_dao, round_id, request_dict):
 def finalize_campaign(user_dao, campaign_id):
     # TODO: add some docs
     coord_dao = CoordinatorDAO.from_campaign(user_dao, campaign_id)
-    last_rnd = coord_dao.campaign.active_round
+    campaign = coord_dao.campaign
+    active_rnd = campaign.active_round
 
-    if not last_rnd:
-        raise InvalidAction('no active rounds')
+    if active_rnd:
+        if active_rnd.vote_method != 'ranking':
+            raise InvalidAction('last round must be finalized before closing campaign')
+        campaign_summary = coord_dao.finalize_ranking_round(active_rnd.id)
+        coord_dao.finalize_campaign()
+        return campaign_summary
 
-    if last_rnd.vote_method != 'ranking':
-        raise InvalidAction('only ranking rounds can be finalized')
+    final_rnds = [r for r in campaign.rounds if r.status == FINALIZED_STATUS]
+    if not final_rnds:
+        raise InvalidAction('campaign has no finalized rounds')
 
-    campaign_summary = coord_dao.finalize_ranking_round(last_rnd.id)
     coord_dao.finalize_campaign()
-    return campaign_summary
-
+    return {'data': 'finalized'}
 
 def reopen_campaign(user_dao, campaign_id):
     coord_dao = CoordinatorDAO.from_campaign(user_dao, campaign_id)


### PR DESCRIPTION
pr fixes #143

the changes addresses:
- Campaign can be closed after the last round is finalized, even when that round is yes/no or rating (not only ranking) and If there’s still an active round, it must be finalized and also if there’s no active round but at least one finalized round, the campaign can be closed.
- “Close campaign” button is shown only when the campaign can be closed (canCloseCampaign), then success message  is sent (“Campaign closed.”) after a successful close.
- Fixed template typo: rroundResults → roundResults so the cancelled-tasks value renders and the Vue warning goes away.

BEFORE 
![ScreenRecording2026-03-10at14 00 09-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2066c3fd-178a-47a5-8a2e-3ae526a71255)

AFTER
![ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/1640d2a1-667f-4b6d-9553-110230f183bb)
