### PR TITLE
Fixes #357 by serializing MontageErrors natively in MessageMiddleware and hardening the round_creation API contract.

### DIFF
--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -461,6 +461,8 @@ def cancel_campaign(user_dao, campaign_id):
 
 def _prepare_round_params(coord_dao, request_dict):
     rnd_dict = {}
+    if not request_dict:
+        request_dict = {}
     req_columns = ['jurors', 'name', 'vote_method', 'deadline_date']
     extra_columns = ['description', 'config', 'directions', 'show_stats']
     valid_vote_methods = ['ranking', 'rating', 'yesno']

--- a/montage/mw/__init__.py
+++ b/montage/mw/__init__.py
@@ -63,16 +63,26 @@ class MessageMiddleware(Middleware):
         try:
             ret = next()
         except Exception as e:
-            if self.debug_errors and not isinstance(e, MontageError):
-                import pdb; pdb.post_mortem()
-                import pdb;pdb.set_trace()
-            if self.raise_errors:
-                raise
-            ret = None
-            exc_info = ExceptionInfo.from_current()
-            err = '%s: %s' % (exc_info.exc_type, exc_info.exc_msg)
-            response_dict['errors'].append(err)
-            response_dict['status'] = 'exception'
+            if isinstance(e, MontageError):
+                err = str(e)
+                # Some clastic errors like BadRequest have a description property
+                if hasattr(e, 'description') and e.description:
+                    err = e.description
+                response_dict['errors'].append(err)
+                response_dict['status'] = 'failure'
+                response_dict['_status_code'] = getattr(e, 'code', getattr(e, 'status_code', 400))
+                ret = None
+            else:
+                if self.debug_errors:
+                    import pdb; pdb.post_mortem()
+                if self.raise_errors:
+                    raise
+                ret = None
+                exc_info = ExceptionInfo.from_current()
+                err = '%s: %s' % (exc_info.exc_type, exc_info.exc_msg)
+                response_dict['errors'].append(err)
+                response_dict['status'] = 'exception'
+                response_dict['_status_code'] = 500
         else:
             status_code = response_dict.pop('_status_code', None)
             if response_dict.get('errors'):


### PR DESCRIPTION
Fixes #357.

The backend was crashing and losing CORS headers when a custom error hit the middleware layer. I just fixed the serializer mapping.