### PR TITLE
Fixes #206: Prevent multiple rapid-voting network submissions

### DIFF
--- a/frontend/src/components/Vote/VoteRating.vue
+++ b/frontend/src/components/Vote/VoteRating.vue
@@ -57,7 +57,7 @@
         <clip-loader v-if="isLoading" color="#36D7B7" size="20px" />
         <div v-else class="vote-controls-button">
           <span v-for="rate in [1, 2, 3, 4, 5]" :key="rate">
-            <cdx-button weight="quiet" @click="setRate(rate)">
+            <cdx-button weight="quiet" @click="setRate(rate)" :disabled="isLoading">
               <star />
             </cdx-button>
           </span>
@@ -85,7 +85,7 @@
           </cdx-button>
         </div>
         <div>
-          <cdx-button weight="quiet" @click="setRate()">
+          <cdx-button weight="quiet" @click="setRate()" :disabled="isLoading">
             <arrow-right class="icon-small" /> {{ $t('montage-vote-skip') }}
           </cdx-button>
           <cdx-button weight="quiet" @click="goPrevVoteEditing">

--- a/frontend/src/components/Vote/VoteYesNo.vue
+++ b/frontend/src/components/Vote/VoteYesNo.vue
@@ -56,10 +56,10 @@
       <div class="vote-controls">
         <clip-loader v-if="isLoading" color="#36D7B7" size="20px" />
         <div v-else class="vote-controls-button">
-          <cdx-button action="progressive" weight="quiet" @click="setRate(5)">
+          <cdx-button action="progressive" weight="quiet" @click="setRate(5)" :disabled="isLoading">
             <thumb-up class="icon-small" /> {{ $t('montage-vote-accept') }}
           </cdx-button>
-          <cdx-button action="destructive" weight="quiet" @click="setRate(1)">
+          <cdx-button action="destructive" weight="quiet" @click="setRate(1)" :disabled="isLoading">
             <thumb-down class="icon-small" /> {{ $t('montage-vote-decline') }}
           </cdx-button>
         </div>
@@ -86,7 +86,7 @@
           </cdx-button>
         </div>
         <div>
-          <cdx-button weight="quiet" @click="setRate()">
+          <cdx-button weight="quiet" @click="setRate()" :disabled="isLoading">
             <arrow-right class="icon-small" /> {{ $t('montage-vote-skip') }}
           </cdx-button>
           <cdx-button weight="quiet" @click="goPrevVoteEditing">


### PR DESCRIPTION
Fixes #206.

Jurors were able to spam the vote keys and trigger duplicate Axios calls rapidly, which confused the backend queue. Threw a quick block/spinner on the frontend to trap it natively.