### PR TITLE
Automate setuptools installation

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,11 @@
+#To install backend packages, run this command in CLI
+# > python3 -m venv venv
+# > source venv/bin/activate
+# > pip install -r requirements-dev.txt 
 -r requirements.txt
 
-tox<3.15.0
+tox<3.15.0  #tox version: 3.15.0 supports pluggy < 1, else we may face version conflict
+pluggy<1
 Fabric3
 coverage==5.0.2
 pytest==4.6.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+setuptools==57.5.0
 #To install backend packages, run this command in CLI
 # > python3 -m venv venv
 # > source venv/bin/activate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ setuptools==57.5.0
 # > pip install -r requirements-dev.txt 
 -r requirements.txt
 
+
 tox<3.15.0  #tox version: 3.15.0 supports pluggy < 1, else we may face version conflict
 pluggy<1
 Fabric3

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
   setuptools
 commands = coverage run --parallel --omit 'flycheck_*' --rcfile {toxinidir}/.tox-coveragerc -m pytest --ignore client/ --doctest-modules {envsitepackagesdir}/montage {posargs}
 
+
 # Uses default basepython otherwise reporting doesn't work on Travis where
 # Python 3.6 is only available in 3.6 jobs.
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py39,py311,coverage-report
 changedir = .tox
 deps =
   -rrequirements-dev.txt
+  setuptools
 commands = coverage run --parallel --omit 'flycheck_*' --rcfile {toxinidir}/.tox-coveragerc -m pytest --ignore client/ --doctest-modules {envsitepackagesdir}/montage {posargs}
 
 # Uses default basepython otherwise reporting doesn't work on Travis where


### PR DESCRIPTION
This pull request  automates the **setuptools**(third party library) installation.

Instead of installing it manually now tox automatically does it,

Added **setuptools** in deps- tox.ini

Before:- 
<img width="1250" height="1041" alt="Screenshot 2026-03-22 at 5 15 07 PM" src="https://github.com/user-attachments/assets/e6f79eeb-5bde-4dda-8170-291a1629286a" />
**without manually installing setuptools** 

 After:-
<img width="1256" height="402" alt="Screenshot 2026-03-22 at 5 17 19 PM" src="https://github.com/user-attachments/assets/6f0b2d6e-a557-4cb7-b60b-ba9b851ccbcd" />

as of now there is no requirement to install it manually.