### PR TITLE
docs: add troubleshooting section for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,33 @@ workflow that adapts to the conventions of all groups.
 ## Testing
 
 `pip install tox` into your virtualenv, then `tox`.
+
+## Local Setup Troubleshooting
+
+If you run into issues setting up the project locally, here are some common fixes:
+
+### Python version
+- Use Python 3.10 (newer versions like 3.14 may cause dependency issues)
+
+### pkg_resources error
+If you see:
+ModuleNotFoundError: No module named 'pkg_resources'
+
+Run:
+pip install "setuptools<82"
+
+### Missing config file
+If you see an error about config.dev.yaml:
+
+Run:
+cp config.default.yaml config.dev.yaml
+
+### Database not initialized
+If you see errors about missing tables:
+
+- The database has not been initialized yet
+- Check project setup steps or scripts to initialize the database
+
+### General tip
+- Always activate your virtual environment before running the app:
+  source venv/bin/activate


### PR DESCRIPTION
## What I changed
Added a troubleshooting section to the README to help with common local setup issues.

## Why
While setting up the project locally, I ran into a few common issues related to Python version compatibility, setuptools/pkg_resources, missing config.dev.yaml, and database setup. This adds a simple troubleshooting section to make onboarding easier for new contributors.

## Notes
These steps are based on issues encountered during local setup.