### PR TITLE
fix(admin): display total file count in round dashboard (#494)

### DIFF
--- a/frontend/src/components/Round/RoundView.vue
+++ b/frontend/src/components/Round/RoundView.vue
@@ -30,7 +30,7 @@
                   ? $t('montage-round-rating')
                   : $t('montage-round-ranking')
             }}
-            . {{ round.status }}
+            · {{ round.status }} · {{ round.total_entries }} {{ $t('montage-round-files') }}
           </p>
         </div>
         <div style="margin-left: auto">

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -431,6 +431,13 @@ class Round(Base):
         return False
 
     def to_info_dict(self):
+        rdb_session = inspect(self).session
+        total_entries = 0
+        if rdb_session:
+            total_entries = rdb_session.query(func.count(RoundEntry.id))\
+                                       .filter(RoundEntry.round_id == self.id)\
+                                       .scalar()
+
         ret = {'id': self.id,
                'name': self.name,
                'directions': self.directions,
@@ -444,6 +451,7 @@ class Round(Base):
                'status': self.status,
                'config': self.config,
                'show_stats': self.show_stats,
+               'total_entries': total_entries,
                'round_sources': []}
         return ret
 


### PR DESCRIPTION
Fixes #494.

Coordinators currently have no way of knowing how many files were successfully imported into a round without running queries.

I updated the `to_info_dict()` method on the Round model to properly return a `total_entries` count by running a fast SQL `func.count()` instead of loading records into memory to avoid SQLAlchemy bottlenecks. Also slapped it on the `RoundView` template so it shows up in the admin dashboard natively.