### PR TITLE
fix: correct rroundResults typo in RoundInfo.vue

### DIFF
--- a/frontend/src/components/Round/RoundInfo.vue
+++ b/frontend/src/components/Round/RoundInfo.vue
@@ -67,7 +67,7 @@
         </p>
         <p>
           <strong>{{ $t('montage-round-cancelled-tasks') }}:</strong>
-          {{ rroundResults?.counts.total_cancelled_tasks }}
+          {{ roundResults?.counts.total_cancelled_tasks }}
         </p>
         <p>
           <strong>{{ $t('montage-round-disqualified-files') }}:</strong>


### PR DESCRIPTION
## What this fixes
The "Cancelled Tasks" stat in the Round Info panel always rendered blank for every round.

## Root cause
Line 70 of RoundInfo.vue references `rroundResults?.counts.total_cancelled_tasks` but the declared ref in this component is `roundResults` (single r). JavaScript resolves `undefined?.anything` silently to `undefined` rather than throwing an error, so the bug never surfaced as a console error — it just always showed blank.

## Fix
Renamed `rroundResults` → `roundResults` on line 70.

## Files changed
- `frontend/src/components/Round/RoundInfo.vue`

## How to verify
1. Open any campaign round that has at least one cancelled task
2. Navigate to the Round Info panel
3. Confirm the "Cancelled Tasks" field now shows the correct number instead of blank

Relates to: T415578