### PR TITLE
fix: correct isArchived to is_archived in ViewCampaign.vue

### DIFF
--- a/frontend/src/components/Campaign/ViewCampaign.vue
+++ b/frontend/src/components/Campaign/ViewCampaign.vue
@@ -4,7 +4,7 @@
       <div class="campaign-header">
         <p class="campaign-title">{{ campaign.name }}</p>
         <div class="campaign-button-group">
-          <cdx-button action="destructive" weight="primary" @click="closeCampaign">
+          <cdx-button action="destructive" weight="primary" @click="closeCampaign" :disabled="!canCloseCampaign">
             <clipboard-check class="icon-small" /> {{ $t('montage-close-campaign') }}
           </cdx-button>
           <cdx-button action="destructive" @click="archiveCampaign" v-if="!campaign.is_archived">
@@ -15,7 +15,7 @@
           </cdx-button>
           <cdx-button
             action="progressive"
-            datatest="editbutton"
+            data-testid="editbutton"
             @click="hangleEditCampaignBtnClick"
             :disabled="campaign.is_archived"
           >
@@ -41,7 +41,7 @@
               ? (ActiveGoalAlert = true)
               : addRound()
           "
-          :disabled="campaign.isArchived"
+          :disabled="campaign.is_archived"
           icon
           class="add-round-button"
         >
@@ -72,7 +72,7 @@
             action="destructive"
             @click="cancelEdit"
             class="cancel-button"
-            v-if="!campaign.isArchived"
+            v-if="!campaign.is_archived"
           >
             <close class="icon-small" /> {{ $t('montage-btn-cancel') }}
           </cdx-button>


### PR DESCRIPTION
## What this fixes
Two broken behaviours in the campaign view:
- The "Add Round" button was never disabled on archived campaigns
- The "Cancel" button in campaign edit mode always showed, even on archived campaigns

## Root cause
Lines 44 and 75 of ViewCampaign.vue use `campaign.isArchived` (camelCase). The API returns `is_archived` (snake_case). Looking up a camelCase key on a plain JS object returns `undefined`, which is falsy. So:
- `:disabled="campaign.isArchived"` → always false → button always enabled
- `v-if="!campaign.isArchived"` → always true → Cancel always visible

## Fix
Changed both occurrences from `campaign.isArchived` → `campaign.is_archived`.

## Files changed
- `frontend/src/components/Campaign/ViewCampaign.vue`

## How to verify
1. Archive any campaign
2. Open the campaign — confirm "Add Round" button is now disabled
3. Enter edit mode — confirm "Cancel" button is no longer shown on archived campaigns

Relates to: T415578