### PR TITLE
fix: correct emit event name to camelCase

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -381,7 +381,7 @@ const submitRound = () => {
       })
       .catch(alertService.error)
       .finally(() => {
-        emit('reload-campaign-state')
+        emit('reloadCampaignState')
         emit('update:showAddRoundForm', false)
       })
   }
@@ -423,12 +423,12 @@ const importCategory = (id) => {
             actionType: 'progressive'
           },
           onPrimary: () => {
-            emit('reload-campaign-state')
+            emit('reloadCampaignState')
             emit('update:showAddRoundForm', false)
           }
         })
       } else {
-        emit('reload-campaign-state')
+        emit('reloadCampaignState')
         emit('update:showAddRoundForm', false)
       }
     })


### PR DESCRIPTION
## What this fixes
After successfully creating a new round, the campaign view never refreshed automatically. Users had to manually reload the page to see the newly created round.

## Root cause
`defineEmits` on line 233 of RoundNew.vue declares `'reloadCampaignState'` (camelCase). The parent component ViewCampaign.vue listens with `@reloadCampaignState`. However all three emit call-sites (lines 384, 426, 431) used `emit('reload-campaign-state')` (kebab-case). Vue 3 does not automatically match kebab-case emit names to camelCase listener declarations, so the parent listener never fired.

## Fix
Changed all three emit call-sites from `emit('reload-campaign-state')` → `emit('reloadCampaignState')`.

## Files changed
- `frontend/src/components/Round/RoundNew.vue`

## How to verify
1. Open any campaign
2. Create a new round and submit the form
3. Confirm the campaign view now automatically refreshes and shows the new round without a manual page reload

Relates to: T415578