### PR TITLE
fix: replace router.reload with location.reload

### DIFF
--- a/frontend/src/components/Round/RoundEdit.vue
+++ b/frontend/src/components/Round/RoundEdit.vue
@@ -191,7 +191,7 @@ const deleteRound = () => {
         .cancelRound(props.round.id)
         .then(() => {
           emit('update:isRoundEditing', false)
-          router.reload()
+          location.reload()
         })
         .catch(alertService.error)
     }


### PR DESCRIPTION
## What this fixes
After deleting a round, the page never refreshed — the deleted round remained visible in the UI even though it had been removed from the database.

## Root cause
Line 194 of RoundEdit.vue calls `router.reload()` after a successful round deletion. Vue Router does not have a `reload()` method — this throws `TypeError: router.reload is not a function` at runtime. Because the error was thrown inside a `.then()` callback, it was silently swallowed and the page never refreshed.

## Fix
Changed `router.reload()` → `location.reload()`, which is the correct browser API for a full page reload. This is consistent with the exact same pattern already used in RoundInfo.vue for `activateRound()` and `pauseRound()`.

## Files changed
- `frontend/src/components/Round/RoundEdit.vue`

## How to verify
1. Open any campaign with at least one round
2. Delete a round using the delete action
3. Confirm the page now refreshes automatically and the deleted round no longer appears

Relates to: T415578