### PR TITLE
Fix: Prevent 500 POST errors via strict frontend schema validation during Round Creation

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -312,17 +312,40 @@ const cancelRound = () => {
 
 const submitRound = () => {
   if (!formData.value.deadline_date) {
-    alertService.error({
-      message: $t('montage-required-voting-deadline')
-    })
+    alertService.error({ message: $t('montage-required-voting-deadline') })
     return
   }
 
-  if (!formData.value.name || (formData.value.quorum > 0 && formData.value.jurors.length === 0)) {
-    alertService.error({
-      message: $t('montage-required-fill-inputs')
-    })
+  if (!formData.value.name || formData.value.name.trim() === '') {
+    alertService.error({ message: $t('montage-required-fill-inputs') })
     return
+  }
+  
+  if (formData.value.quorum <= 0 || (formData.value.quorum > 0 && formData.value.jurors.length === 0)) {
+    alertService.error({ message: $t('montage-error-invalid-quorum') })
+    return
+  }
+
+  if (roundIndex === 0) {
+    // Validate Import Source for first round
+    if (selectedImportSource.value === 'category' && !importSourceValue.value.category) {
+      alertService.error({ message: $t('montage-error-missing-category') })
+      return
+    }
+    if (selectedImportSource.value === 'csv' && (!importSourceValue.value.csv_url || importSourceValue.value.csv_url.trim() === '')) {
+      alertService.error({ message: $t('montage-error-missing-csv') })
+      return
+    }
+    if (selectedImportSource.value === 'selected' && (!importSourceValue.value.file_names || importSourceValue.value.file_names.trim() === '')) {
+      alertService.error({ message: $t('montage-error-missing-file-list') })
+      return
+    }
+  } else {
+    // Validate Thresholds for subsequent rounds
+    if (!formData.value.threshold) {
+      alertService.error({ message: $t('montage-error-missing-threshold') })
+      return
+    }
   }
 
   // Check if the round is the first round

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -186,5 +186,10 @@
   "permission-denied-message": "You do not have the required permissions to access this page.",
   "permission-denied-home": "Go to Home",
   "montage-required-voting-deadline": "Choose a valid voting deadline",
-  "montage-required-fill-inputs": "Please fill all the boxes"
+  "montage-required-fill-inputs": "Please fill all the boxes",
+  "montage-error-missing-category": "Please provide a valid category",
+  "montage-error-missing-csv": "Please provide a valid CSV URL",
+  "montage-error-missing-file-list": "Please provide at least one file name",
+  "montage-error-missing-threshold": "Please select a threshold",
+  "montage-error-invalid-quorum": "Quorum must be greater than 0 and jurors must be selected if quorum is greater than 0."
 }


### PR DESCRIPTION
Fixes #447.

Tightened the frontend constraints on `RoundNew.vue` so people can't submit broken or empty round configurations and trigger unhandled 500 stack traces on the backend.