### PR TITLE
Added frontend validation before advanceRound

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -307,6 +307,16 @@ const submitRound = () => {
       alertService.error($t('montage-something-went-wrong'))
       return
     }
+    if (
+      formData.value.vote_method === 'ranking' &&
+      thresholds.value &&
+      (formData.value.threshold === null || formData.value.threshold === '')
+    ) {
+      alertService.error({
+        message: $t('montage-round-threshold-default')
+      })
+      return
+    }
 
     const payload = {
       next_round: {
@@ -327,7 +337,7 @@ const submitRound = () => {
       })
       .catch(alertService.error)
       .finally(() => {
-        emit('reload-campaign-state')
+        emit('reloadCampaignState')
         emit('update:showAddRoundForm', false)
       })
   }
@@ -369,12 +379,12 @@ const importCategory = (id) => {
             actionType: 'progressive'
           },
           onPrimary: () => {
-            emit('reload-campaign-state')
+            emit('reloadCampaignState')
             emit('update:showAddRoundForm', false)
           }
         })
       } else {
-        emit('reload-campaign-state')
+        emit('reloadCampaignState')
         emit('update:showAddRoundForm', false)
       }
     })


### PR DESCRIPTION
this pr addresses and issue i encouter while inspecting the codebase when advancing to a ranking round, if threshold options were loaded but the user never picked one, the form could still submit and fail on the API (often shown as a generic network error). The UI now blocks submit and asks the user to choose a threshold first.
so i fixed it by adding :
- Fixed event-name mismatch: emit reloadCampaignState consistently (3 places)
- a required threshold validation for ranking advance flow
