### PR TITLE
fix: finalize_round: delegate to proper DAO methods instead of bare s…

### DIFF
--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -14,8 +14,7 @@ from .utils import (format_date,
                    NotImplementedResponse,
                    js_isoparse)
 
-from .rdb import (FINALIZED_STATUS,
-                 CoordinatorDAO,
+from .rdb import (CoordinatorDAO,
                  MaintainerDAO,
                  OrganizerDAO)
 
@@ -418,9 +417,28 @@ def pause_round(user_dao, round_id, request_dict):
 def finalize_round(user_dao, round_id, request_dict):
     coord_dao = CoordinatorDAO.from_round(user_dao, round_id)
     rnd = coord_dao.get_round(round_id)
-    rnd.status = FINALIZED_STATUS
 
-    return {'status': 'success'}
+    if rnd.vote_method == 'ranking':
+        result_summary = coord_dao.finalize_ranking_round(round_id)
+        return {'status': 'success',
+                'result_summary_id': result_summary.id}
+    elif rnd.vote_method in ('rating', 'yesno'):
+        try:
+            raw_threshold = request_dict['threshold']
+        except KeyError:
+            raise InvalidAction('threshold is required to finalize a rating/yesno round')
+        try:
+            threshold = float(raw_threshold)
+        except (TypeError, ValueError):
+            raise InvalidAction('threshold must be a number between 0.0 and 1.0 to finalize a rating/yesno round')
+        if not (0.0 <= threshold <= 1.0):
+            raise InvalidAction('threshold must be between 0.0 and 1.0 to finalize a rating/yesno round')
+        advance_group = coord_dao.finalize_rating_round(round_id, threshold=threshold)
+        return {'status': 'success',
+                'advancing_count': len(advance_group),
+                'threshold': threshold}
+    else:
+        raise InvalidAction('unknown vote method: %s' % rnd.vote_method)
 
 def edit_campaign(user_dao, campaign_id, request_dict):
     """

--- a/montage/tests/conftest.py
+++ b/montage/tests/conftest.py
@@ -12,11 +12,18 @@ from __future__ import absolute_import
 
 import json
 import re
-
+import os
 import pytest
+
 import responses as responses_lib
 
 from urllib.parse import parse_qs, urlparse
+from sqlalchemy import create_engine
+from boltons.fileutils import mkdir_p
+from montage import utils
+from montage.app import create_app, STATIC_PATH
+from montage.rdb import Base
+from montage.tests.test_web_basic import MontageTestClient
 
 # ---------------------------------------------------------------------------
 # URLs exactly as constructed by montage code
@@ -191,3 +198,25 @@ def mock_external_apis():
         )
 
         yield rsps
+
+@pytest.fixture
+def montage_app(tmpdir):
+    config = utils.load_env_config(env_name='devtest')
+    config['db_url'] = config['db_url'].replace('///', '///' + str(tmpdir) + '/')
+    engine = create_engine(config['db_url'])
+    Base.metadata.create_all(engine)
+
+    index_path = STATIC_PATH + '/index.html'
+    if not os.path.exists(index_path):
+        mkdir_p(STATIC_PATH)
+        with open(index_path, 'w') as f:
+            f.write('<html><body>just for tests</body></html>')
+
+    return create_app('devtest', config=config)
+
+
+@pytest.fixture
+def api_client(montage_app):
+    client = MontageTestClient(montage_app, base_path='/v1')
+    client.set_session_cookie(montage_app.resources['config']['dev_local_cookie_value'])
+    return client

--- a/montage/tests/test_finalize_round.py
+++ b/montage/tests/test_finalize_round.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+
+"""
+Integration tests for round finalization endpoint (/admin/round/<id>/finalize).
+
+Tests cover:
+- Ranking round finalization (result_summary creation)
+- Rating/YesNo round finalization with threshold validation
+- Threshold validation errors (missing, non-numeric, out of range)
+
+Fixtures (montage_app, api_client) are provided by conftest.py.
+"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+from montage.tests.test_web_basic import submit_ratings
+
+
+def test_finalize_ranking_round(api_client):
+    """finalize_round with ranking vote method returns result_summary_id."""
+    fetch = api_client.fetch
+
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    resp = fetch('organizer: create campaign',
+                 '/admin/add_campaign',
+                 {'name': 'Finalize Ranking Test Campaign',
+                  'coordinators': [u'LilyOfTheWest'],
+                  'close_date': '2025-10-01 17:00:00',
+                  'url': 'http://hatnote.com',
+                  'series_id': series_id},
+                 as_user='LilyOfTheWest')
+    campaign_id = resp['data']['id']
+
+    resp = fetch('coordinator: add ranking round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 {'name': 'Test ranking round',
+                  'vote_method': 'ranking',
+                  'quorum': 2,
+                  'deadline_date': '2025-10-20T00:00:00',
+                  'jurors': [u'Slaporte', u'Effeietsanders']},
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    fetch('coordinator: import entries',
+          '/admin/round/%s/import' % round_id,
+          {'import_method': 'category',
+           'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+          as_user='LilyOfTheWest')
+
+    fetch('coordinator: activate round',
+          '/admin/round/%s/activate' % round_id,
+          {'post': True}, as_user='LilyOfTheWest')
+
+    submit_ratings(api_client, round_id, coord_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: finalize ranking round',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'post': True}, as_user='LilyOfTheWest')
+
+    assert resp['status'] == 'success'
+    assert isinstance(resp['data']['result_summary_id'], int)
+
+
+def test_finalize_rating_round_with_threshold(api_client):
+    """finalize_round with rating vote method and valid threshold returns advancing_count."""
+    fetch = api_client.fetch
+
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    resp = fetch('organizer: create campaign',
+                 '/admin/add_campaign',
+                 {'name': 'Finalize Rating Test Campaign',
+                  'coordinators': [u'LilyOfTheWest'],
+                  'close_date': '2025-10-01 17:00:00',
+                  'url': 'http://hatnote.com',
+                  'series_id': series_id},
+                 as_user='LilyOfTheWest')
+    campaign_id = resp['data']['id']
+
+    resp = fetch('coordinator: add rating round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 {'name': 'Test rating round',
+                  'vote_method': 'rating',
+                  'quorum': 2,
+                  'deadline_date': '2025-10-20T00:00:00',
+                  'jurors': [u'Slaporte', u'Effeietsanders']},
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    fetch('coordinator: import entries',
+          '/admin/round/%s/import' % round_id,
+          {'import_method': 'category',
+           'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+          as_user='LilyOfTheWest')
+
+    fetch('coordinator: activate round',
+          '/admin/round/%s/activate' % round_id,
+          {'post': True}, as_user='LilyOfTheWest')
+
+    submit_ratings(api_client, round_id, coord_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: finalize rating round',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'threshold': 0.5}, as_user='LilyOfTheWest')
+
+    assert resp['status'] == 'success'
+    assert isinstance(resp['data']['advancing_count'], int)
+    assert resp['data']['threshold'] == 0.5
+
+
+def test_finalize_yesno_round_with_threshold(api_client):
+    """finalize_round with yesno vote method and valid threshold returns advancing_count."""
+    fetch = api_client.fetch
+
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    resp = fetch('organizer: create campaign',
+                 '/admin/add_campaign',
+                 {'name': 'Finalize YesNo Test Campaign',
+                  'coordinators': [u'LilyOfTheWest'],
+                  'close_date': '2025-10-01 17:00:00',
+                  'url': 'http://hatnote.com',
+                  'series_id': series_id},
+                 as_user='LilyOfTheWest')
+    campaign_id = resp['data']['id']
+
+    resp = fetch('coordinator: add yesno round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 {'name': 'Test yesno round',
+                  'vote_method': 'yesno',
+                  'quorum': 2,
+                  'deadline_date': '2025-10-20T00:00:00',
+                  'jurors': [u'Slaporte', u'Effeietsanders']},
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    fetch('coordinator: import entries',
+          '/admin/round/%s/import' % round_id,
+          {'import_method': 'category',
+           'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+          as_user='LilyOfTheWest')
+
+    fetch('coordinator: activate round',
+          '/admin/round/%s/activate' % round_id,
+          {'post': True}, as_user='LilyOfTheWest')
+
+    submit_ratings(api_client, round_id, coord_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: finalize yesno round',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'threshold': 0.5}, as_user='LilyOfTheWest')
+
+    assert resp['status'] == 'success'
+    assert isinstance(resp['data']['advancing_count'], int)
+    assert resp['data']['threshold'] == 0.5
+
+
+def _setup_active_round(fetch, vote_method):
+    """Helper: create campaign, add a round of given vote_method, import entries, activate."""
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    resp = fetch('organizer: create campaign',
+                 '/admin/add_campaign',
+                 {'name': 'Threshold Validation Campaign (%s)' % vote_method,
+                  'coordinators': [u'LilyOfTheWest'],
+                  'close_date': '2025-10-01 17:00:00',
+                  'url': 'http://hatnote.com',
+                  'series_id': series_id},
+                 as_user='LilyOfTheWest')
+    campaign_id = resp['data']['id']
+
+    resp = fetch('coordinator: add round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 {'name': 'Test %s round' % vote_method,
+                  'vote_method': vote_method,
+                  'quorum': 2,
+                  'deadline_date': '2025-10-20T00:00:00',
+                  'jurors': [u'Slaporte', u'Effeietsanders']},
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    fetch('coordinator: import entries',
+          '/admin/round/%s/import' % round_id,
+          {'import_method': 'category',
+           'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+          as_user='LilyOfTheWest')
+
+    fetch('coordinator: activate round',
+          '/admin/round/%s/activate' % round_id,
+          {'post': True}, as_user='LilyOfTheWest')
+
+    return round_id
+
+
+def test_finalize_round_missing_threshold(api_client):
+    """finalize_round without threshold raises InvalidAction (400) for rating/yesno rounds."""
+    fetch = api_client.fetch
+    round_id = _setup_active_round(fetch, 'yesno')
+
+    resp = fetch('coordinator: try finalize without threshold',
+                 '/admin/round/%s/finalize' % round_id,
+                 {}, as_user='LilyOfTheWest', error_code=400)
+
+    assert resp['status'] == 'failure'
+    assert 'threshold is required' in resp['errors']
+
+
+def test_finalize_round_non_numeric_threshold(api_client):
+    """finalize_round with a non-numeric threshold raises InvalidAction (400)."""
+    fetch = api_client.fetch
+    round_id = _setup_active_round(fetch, 'rating')
+
+    resp = fetch('coordinator: try finalize with string threshold',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'threshold': 'abc'}, as_user='LilyOfTheWest', error_code=400)
+
+    assert resp['status'] == 'failure'
+    assert 'threshold must be a number' in resp['errors']
+
+    resp = fetch('coordinator: try finalize with empty string threshold',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'threshold': ''}, as_user='LilyOfTheWest', error_code=400)
+
+    assert resp['status'] == 'failure'
+    assert 'threshold must be a number' in resp['errors']
+
+
+def test_finalize_round_threshold_out_of_range(api_client):
+    """finalize_round with threshold outside [0.0, 1.0] raises InvalidAction (400)."""
+    fetch = api_client.fetch
+    round_id = _setup_active_round(fetch, 'yesno')
+
+    resp = fetch('coordinator: try finalize with threshold above 1.0',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'threshold': 1.5}, as_user='LilyOfTheWest', error_code=400)
+
+    assert resp['status'] == 'failure'
+    assert 'threshold must be between 0.0 and 1.0' in resp['errors']
+
+    resp = fetch('coordinator: try finalize with negative threshold',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'threshold': -0.5}, as_user='LilyOfTheWest', error_code=400)
+
+    assert resp['status'] == 'failure'
+    assert 'threshold must be between 0.0 and 1.0' in resp['errors']


### PR DESCRIPTION
…tatus update

## Summary

Fix the `finalize_round` endpoint in `admin_endpoints.py` to ensure all required finalization actions are executed by delegating to the appropriate DAO methods instead of only updating the round status.

## Solution

The endpoint now properly delegates round finalization logic to the DAO layer:

* Calls `finalize_rating_round` for rating rounds
* Calls `finalize_ranking_round` for ranking rounds
* Ensures all expected finalization side-effects are executed

**Fixes** #462 

## Changes

* Call DAO finalization methods instead of directly updating status
* Ensure `close_date` is set during finalization
* Ensure audit log entries are created
* Ensure ranking rounds create `RoundResultsSummary`
* Ensure rating rounds store `final_threshold` in config
* Remove unused `FINALIZED_STATUS` import

## How to test

1. Create a campaign and add a round
2. Activate the round and complete voting
3. Finalize the round via the endpoint
4. Verify:

   * `close_date` is set in the database
   * Audit log entry exists for finalization
   * Ranking rounds create a `RoundResultsSummary`
   * Rating rounds store `final_threshold` in config


