### PR TITLE
Style: Normalize backend endpoint URL slashes for Axios consistency

### DIFF
--- a/frontend/src/services/adminService.js
+++ b/frontend/src/services/adminService.js
@@ -49,7 +49,7 @@ const adminService = {
 
   advanceRound: (id, data) => apiBackend.post(`admin/round/${id}/advance`, data),
 
-  finalizeRound: (id) => apiBackend.post(`/admin/round/${id}/finalize`),
+  finalizeRound: (id) => apiBackend.post(`admin/round/${id}/finalize`),
 
   // Direct download URLs (manual baseURL needed)
   downloadRound: (id) => `${apiBackend.defaults.baseURL}admin/round/${id}/results/download`,


### PR DESCRIPTION
Quick style cleanup.

Forced explicit trailing slashes onto the Axios base URLs so we aren't wasting time relying on the native router doing auto-301 redirects.