### PR TITLE
fix(dao): enforce strict DAO finalization — audit logs, close_date, and summary placement

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -21,7 +21,7 @@ jobs:
             -v "${{ github.workspace }}":/app \
             -e PYTHONPATH=/app \
             montage-ci \
-            python -m pytest montage/tests/test_web_basic.py \
+            python -m pytest montage/tests/ \
               -v --tb=short -p no:cacheprovider
 
       - name: Verify backend imports

--- a/dockerfile
+++ b/dockerfile
@@ -8,6 +8,6 @@ COPY requirements.txt .
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
-RUN pip install pytest
+RUN pip install pytest responses
 
 EXPOSE 5000

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -417,8 +417,7 @@ def pause_round(user_dao, round_id, request_dict):
 
 def finalize_round(user_dao, round_id, request_dict):
     coord_dao = CoordinatorDAO.from_round(user_dao, round_id)
-    rnd = coord_dao.get_round(round_id)
-    rnd.status = FINALIZED_STATUS
+    coord_dao.finalize_round(round_id)
 
     return {'status': 'success'}
 

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -1805,21 +1805,22 @@ class CoordinatorDAO(UserDAO):
         rnd.status = FINALIZED_STATUS
         # rnd.config['ranking_method'] = method
 
-        summary = self.build_campaign_report()
-
-        result_summary = RoundResultsSummary(round_id=round_id,
-                                             campaign_id=rnd.campaign.id,
-                                             summary=summary)
-        self.rdb_session.add(result_summary)
-        self.rdb_session.flush()
-        msg = ('%s finalized round "%s" (#%s) and created round results summary %s' %
-               (self.user.username, rnd.name, rnd.id, result_summary.id))
+        msg = ('%s finalized ranking round "%s" (#%s)' %
+               (self.user.username, rnd.name, rnd.id))
         self.log_action('finalize_ranking_round', round=rnd, message=msg)
-        return result_summary
-
+        return rnd
     def finalize_campaign(self):
         last_rnd = self.campaign.rounds[-1] if len(self.campaign.rounds) > 0 else None
         self.campaign.status = FINALIZED_STATUS
+        if last_rnd and last_rnd.vote_method == 'ranking':
+            summary = self.build_campaign_report()
+            result_summary = RoundResultsSummary(
+                round_id=last_rnd.id,
+                campaign_id=self.campaign.id,
+                summary=summary)
+            self.rdb_session.add(result_summary)
+            self.rdb_session.flush()
+            
         #self.campaign.close_date = datetime.datetime.utcnow() # TODO
         if last_rnd:
             msg = ('%s finalized campaign %r (#%s) with %s round "%s"'

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -1784,6 +1784,19 @@ class CoordinatorDAO(UserDAO):
         
         return rnd
 
+    def finalize_round(self, round_id):
+        rnd = self.get_round(round_id)
+        if rnd.vote_method == 'ranking':
+            return self.finalize_ranking_round(round_id)
+            
+        rnd.close_date = datetime.datetime.utcnow()
+        rnd.status = FINALIZED_STATUS
+        
+        msg = ('%s finalized %s round "%s" (#%s)' % 
+               (self.user.username, rnd.vote_method, rnd.name, rnd.id))
+        self.log_action('finalize_round', round=rnd, message=msg)
+        return rnd
+
     def finalize_ranking_round(self, round_id):
         rnd = self.get_round(round_id)
         assert rnd.vote_method == 'ranking'

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -1553,6 +1553,22 @@ class CoordinatorDAO(UserDAO):
 
         return
 
+    def finalize_round(self, round_id):
+        rnd = self.get_round(round_id)
+        rnd.close_date = datetime.datetime.utcnow()
+        rnd.status = FINALIZED_STATUS
+
+        msg = '%s finalized round "%s" (#%s)' % (self.user.username,
+                                                 rnd.name,
+                                                 rnd.id)
+        self.log_action('finalize_round', round=rnd, message=msg)
+        
+        if rnd.vote_method == 'ranking':
+            # Note: RoundResultsSummary creation is handled in finalize_campaign
+            pass
+
+        return rnd
+
     def add_entries_from_cat(self, round_id, cat_name):
         rnd = self.user_dao.get_round(round_id)
         if ENV_NAME == 'dev':
@@ -1784,34 +1800,20 @@ class CoordinatorDAO(UserDAO):
         
         return rnd
 
-    def finalize_round(self, round_id):
-        rnd = self.get_round(round_id)
-        if rnd.vote_method == 'ranking':
-            return self.finalize_ranking_round(round_id)
-            
-        rnd.close_date = datetime.datetime.utcnow()
-        rnd.status = FINALIZED_STATUS
-        
-        msg = ('%s finalized %s round "%s" (#%s)' % 
-               (self.user.username, rnd.vote_method, rnd.name, rnd.id))
-        self.log_action('finalize_round', round=rnd, message=msg)
-        return rnd
-
     def finalize_ranking_round(self, round_id):
         rnd = self.get_round(round_id)
         assert rnd.vote_method == 'ranking'
-
-        rnd.close_date = datetime.datetime.utcnow()
-        rnd.status = FINALIZED_STATUS
-        # rnd.config['ranking_method'] = method
-
-        msg = ('%s finalized ranking round "%s" (#%s)' %
-               (self.user.username, rnd.name, rnd.id))
-        self.log_action('finalize_ranking_round', round=rnd, message=msg)
+        
+        # This is now handled by the generic finalize_round dispatcher
+        # but kept for backward compatibility or specific ranking logic if needed.
+        # Currently just returns the round.
+        
         return rnd
+
     def finalize_campaign(self):
         last_rnd = self.campaign.rounds[-1] if len(self.campaign.rounds) > 0 else None
         self.campaign.status = FINALIZED_STATUS
+        
         if last_rnd and last_rnd.vote_method == 'ranking':
             summary = self.build_campaign_report()
             result_summary = RoundResultsSummary(
@@ -1820,7 +1822,7 @@ class CoordinatorDAO(UserDAO):
                 summary=summary)
             self.rdb_session.add(result_summary)
             self.rdb_session.flush()
-            
+
         #self.campaign.close_date = datetime.datetime.utcnow() # TODO
         if last_rnd:
             msg = ('%s finalized campaign %r (#%s) with %s round "%s"'

--- a/montage/tests/conftest.py
+++ b/montage/tests/conftest.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""
+Shared test fixtures.
+
+Mocks all external HTTP calls (Toolforge API, Google Sheets, Wikimedia
+API) so tests run without network access.  The ``responses`` library
+intercepts at the ``requests`` adapter level; any unmocked call raises
+``ConnectionError`` (passthrough=False, the default).
+"""
+
+from __future__ import absolute_import
+
+import json
+import re
+
+import pytest
+import responses as responses_lib
+
+from urllib.parse import parse_qs, urlparse
+
+# ---------------------------------------------------------------------------
+# URLs exactly as constructed by montage code
+# ---------------------------------------------------------------------------
+TOOLFORGE_CATEGORY_URL = 'https://montage.toolforge.org/v1/utils//category'
+TOOLFORGE_FILE_URL = 'https://montage.toolforge.org/v1/utils//file'
+
+# Matches any Google Sheets CSV-export URL regardless of doc ID.
+GSHEET_CSV_URL_RE = re.compile(
+    r'https://docs\.google\.com/spreadsheets/d/.+/gviz/tq\?tqx=out:csv'
+)
+
+# Matches any Wikimedia API user-lookup call.
+MW_API_URL_RE = re.compile(
+    r'https://commons\.wikimedia\.org/w/api\.php\?.*'
+)
+
+# ---------------------------------------------------------------------------
+# Fixture data -- 20 synthetic entries with resolution > 2 megapixels.
+# Enough entries to survive disqualification AND give every juror >=2
+# tasks regardless of random.shuffle ordering during task allocation.
+# ---------------------------------------------------------------------------
+
+
+def _generate_file_infos(n):
+    """Build *n* unique file-info dicts with high resolution."""
+    infos = []
+    for i in range(n):
+        infos.append({
+            'img_name': 'Test_WLM_2015_image_%03d.jpg' % (i + 1),
+            'img_major_mime': 'image',
+            'img_minor_mime': 'jpeg',
+            'img_width': '3264',
+            'img_height': '2448',  # 3264*2448 = 7,990,272 > 2M
+            'img_user': '5193613',
+            'img_user_text': 'Khoshamadgou',
+            # All timestamps after campaign open_date (2015-09-01)
+            'img_timestamp': '201509060%05d' % (20000 + i),
+        })
+    return infos
+
+
+FIXTURE_FILE_INFOS = _generate_file_infos(20)
+
+# Entry returned for the single-filename import in test_web_basic.py
+SELECTED_FILE_INFO = {
+    'img_name': u'Reynisfjara, Su\u00f0urland, Islandia, 2014-08-17, DD 164.JPG',
+    'img_major_mime': 'image',
+    'img_minor_mime': 'jpeg',
+    'img_width': '4928',
+    'img_height': '3280',
+    'img_user': '12345',
+    'img_user_text': 'TestUploader',
+    'img_timestamp': '20140817120000',
+}
+
+CSV_FULL_COLS = [
+    'img_name', 'img_major_mime', 'img_minor_mime',
+    'img_width', 'img_height', 'img_user',
+    'img_user_text', 'img_timestamp',
+]
+
+
+def build_full_csv(file_infos=None):
+    """Build a CSV string with all required columns from file_info dicts."""
+    if file_infos is None:
+        file_infos = FIXTURE_FILE_INFOS
+    lines = [','.join(CSV_FULL_COLS)]
+    for fi in file_infos:
+        lines.append(','.join(str(fi[c]) for c in CSV_FULL_COLS))
+    return '\n'.join(lines) + '\n'
+
+
+def build_filename_csv(file_infos=None):
+    """Build a CSV string with only a 'filename' column."""
+    if file_infos is None:
+        file_infos = FIXTURE_FILE_INFOS
+    lines = ['filename']
+    for fi in file_infos:
+        lines.append(fi['img_name'])
+    return '\n'.join(lines) + '\n'
+
+
+FIXTURE_FULL_CSV = build_full_csv()
+FIXTURE_FILENAME_CSV = build_filename_csv()
+
+
+# ---------------------------------------------------------------------------
+# Disable pdb in error handler -- devtest sets debug_errors=True which
+# calls pdb.post_mortem() on unhandled exceptions.  Under pytest's output
+# capture this crashes with OSError.  Patching pdb to no-ops is safe
+# because no test relies on interactive debugging.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _disable_pdb(monkeypatch):
+    monkeypatch.setattr('pdb.set_trace', lambda *a, **kw: None)
+    monkeypatch.setattr('pdb.post_mortem', lambda *a, **kw: None)
+
+# ---------------------------------------------------------------------------
+# Wikimedia API callback -- returns a plausible user record for any username
+# ---------------------------------------------------------------------------
+def _wikimedia_user_callback(request):
+    """Return a mock globalallusers response matching the requested username."""
+    parsed = urlparse(request.url)
+    params = parse_qs(parsed.query)
+    username = params.get('agufrom', ['Unknown'])[0]
+    # Deterministic fake user ID derived from username
+    user_id = abs(hash(username)) % 10**8
+    body = json.dumps({
+        'query': {
+            'globalallusers': [
+                {'name': username, 'id': str(user_id)}
+            ]
+        }
+    })
+    return (200, {}, body)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: mock_external_apis
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def mock_external_apis():
+    """Activate ``responses`` and register mocks for every external endpoint.
+
+    Covers:
+    - Toolforge category lookup  (POST /v1/utils//category)
+    - Toolforge file lookup      (POST /v1/utils//file)
+    - Google Sheets CSV export   (GET  docs.google.com/spreadsheets/...)
+    - Wikimedia user lookup       (GET  commons.wikimedia.org/w/api.php)
+
+    Any request to an unregistered URL raises ``ConnectionError``,
+    ensuring no live HTTP traffic leaks from tests.
+    """
+    with responses_lib.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        # -- Toolforge category endpoint --
+        rsps.add(
+            responses_lib.POST,
+            TOOLFORGE_CATEGORY_URL,
+            json={'file_infos': FIXTURE_FILE_INFOS, 'no_info': []},
+            status=200,
+        )
+
+        # -- Toolforge file-lookup endpoint --
+        # Returns both fixture entries and the single "selected" entry so
+        # that both bulk-filename and single-filename imports succeed.
+        rsps.add(
+            responses_lib.POST,
+            TOOLFORGE_FILE_URL,
+            json={
+                'file_infos': FIXTURE_FILE_INFOS + [SELECTED_FILE_INFO],
+                'no_info': [],
+            },
+            status=200,
+        )
+
+        # -- Google Sheets CSV export (any doc ID) --
+        rsps.add(
+            responses_lib.GET,
+            GSHEET_CSV_URL_RE,
+            body=FIXTURE_FULL_CSV,
+            status=200,
+            content_type='text/csv',
+        )
+
+        # -- Wikimedia user-lookup API --
+        # Called by get_mw_userid() when creating new users.
+        rsps.add_callback(
+            responses_lib.GET,
+            MW_API_URL_RE,
+            callback=_wikimedia_user_callback,
+        )
+
+        yield rsps

--- a/montage/tests/test_loaders.py
+++ b/montage/tests/test_loaders.py
@@ -1,29 +1,92 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
-
 from __future__ import absolute_import
+
+import responses
 from pytest import raises
 
 from montage.loaders import get_entries_from_gsheet
+
+from .conftest import (
+    FIXTURE_FILE_INFOS,
+    FIXTURE_FULL_CSV,
+    FIXTURE_FILENAME_CSV,
+    TOOLFORGE_FILE_URL,
+)
 
 RESULTS = 'https://docs.google.com/spreadsheets/d/1RDlpT23SV_JB1mIz0OA-iuc3MNdNVLbaK_LtWAC7vzg/edit?usp=sharing'
 FILENAME_LIST = 'https://docs.google.com/spreadsheets/d/1Nqj-JsX3L5qLp5ITTAcAFYouglbs5OpnFwP6zSFpa0M/edit?usp=sharing'
 GENERIC_CSV = 'https://docs.google.com/spreadsheets/d/1WzHFg_bhvNthRMwNmxnk010KJ8fwuyCrby29MvHUzH8/edit#gid=550467819'
 FORBIDDEN_SHEET = 'https://docs.google.com/spreadsheets/d/1tza92brMKkZBTykw3iS6X9ij1D4_kvIYAiUlq1Yi7Fs/edit'
 
+# Pre-compute the actual fetch URLs that loaders.py constructs from the
+# doc IDs embedded in the spreadsheet URLs above.
+_RESULTS_CSV_URL = 'https://docs.google.com/spreadsheets/d/1RDlpT23SV_JB1mIz0OA-iuc3MNdNVLbaK_LtWAC7vzg/gviz/tq?tqx=out:csv'
+_FILENAME_CSV_URL = 'https://docs.google.com/spreadsheets/d/1Nqj-JsX3L5qLp5ITTAcAFYouglbs5OpnFwP6zSFpa0M/gviz/tq?tqx=out:csv'
+_GENERIC_CSV_URL = 'https://docs.google.com/spreadsheets/d/1WzHFg_bhvNthRMwNmxnk010KJ8fwuyCrby29MvHUzH8/gviz/tq?tqx=out:csv'
+_FORBIDDEN_CSV_URL = 'https://docs.google.com/spreadsheets/d/1tza92brMKkZBTykw3iS6X9ij1D4_kvIYAiUlq1Yi7Fs/gviz/tq?tqx=out:csv'
+
+
+@responses.activate
 def test_load_results():
+    """Full CSV with all required columns -- entries created directly."""
+    responses.add(
+        responses.GET,
+        _RESULTS_CSV_URL,
+        body=FIXTURE_FULL_CSV,
+        status=200,
+        content_type='text/csv',
+    )
     imgs, warnings = get_entries_from_gsheet(RESULTS, source='remote')
-    assert len(imgs) == 331
+    assert len(imgs) == len(FIXTURE_FILE_INFOS)
 
+
+@responses.activate
 def test_load_filenames():
-    imgs, warnings = get_entries_from_gsheet(FILENAME_LIST, source='remote') 
-    assert len(imgs) == 89
+    """Partial CSV with only 'filename' column -- triggers Toolforge lookup."""
+    responses.add(
+        responses.GET,
+        _FILENAME_CSV_URL,
+        body=FIXTURE_FILENAME_CSV,
+        status=200,
+        content_type='text/csv',
+    )
+    # The filename-only CSV triggers load_partial_csv -> load_name_list
+    # -> get_by_filename_remote -> POST to Toolforge /file endpoint.
+    responses.add(
+        responses.POST,
+        TOOLFORGE_FILE_URL,
+        json={'file_infos': FIXTURE_FILE_INFOS, 'no_info': []},
+        status=200,
+    )
+    imgs, warnings = get_entries_from_gsheet(FILENAME_LIST, source='remote')
+    assert len(imgs) == len(FIXTURE_FILE_INFOS)
 
+
+@responses.activate
 def test_load_csv():
-    imgs, warnings = get_entries_from_gsheet(GENERIC_CSV, source='remote') 
-    assert len(imgs) == 93
+    """Generic full CSV -- same path as test_load_results."""
+    responses.add(
+        responses.GET,
+        _GENERIC_CSV_URL,
+        body=FIXTURE_FULL_CSV,
+        status=200,
+        content_type='text/csv',
+    )
+    imgs, warnings = get_entries_from_gsheet(GENERIC_CSV, source='remote')
+    assert len(imgs) == len(FIXTURE_FILE_INFOS)
 
+
+@responses.activate
 def test_no_persmission():
+    """Non-CSV content-type signals a permission / sharing error."""
+    responses.add(
+        responses.GET,
+        _FORBIDDEN_CSV_URL,
+        body='<html><body>Sign in</body></html>',
+        status=200,
+        content_type='text/html',
+    )
     with raises(ValueError):
-        imgs, warnings = get_entries_from_gsheet(FORBIDDEN_SHEET, source='remote')
+        get_entries_from_gsheet(FORBIDDEN_SHEET, source='remote')

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -165,7 +165,7 @@ def api_client(montage_app):
     return api_client
 
 
-def test_home_client(base_client, api_client):
+def test_home_client(base_client, api_client, mock_external_apis):
 
     resp = base_client.fetch('organizer: home', '/')
     #resp = base_client.fetch('public: login', '/login')
@@ -821,7 +821,7 @@ def test_home_client(base_client, api_client):
     #resp = base_client.fetch('public: logout', '/logout')
 
 
-def test_multiple_jurors(api_client):
+def test_multiple_jurors(api_client, mock_external_apis):
     # This is copied from above. What's the best way to break up the tests into
     # various stages? Should I use a pytest.fixture?
     fetch = api_client.fetch

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -954,3 +954,62 @@ def submit_ratings(client, round_id, coord_user='Yarl'):
     # get all the jurors that have open tasks in a round
     # get juror's tasks
     # submit random valid votes until there are no more tasks
+
+def test_finalize_round_sets_close_date_and_logs_action(api_client,
+                                                        mock_external_apis):
+    fetch = api_client.fetch
+
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    campaign_data = {'name': 'Finalize Round Regression Campaign',
+                     'coordinators': [u'LilyOfTheWest',
+                                      u'Yarl'],
+                     'close_date': '2015-10-01 17:00:00',
+                     'url': 'http://hatnote.com',
+                     'series_id': series_id}
+    resp = fetch('organizer: create campaign',
+                 '/admin/add_campaign',
+                 campaign_data,
+                 as_user='Yarl')
+    campaign_id = resp['data']['id']
+
+    rnd_data = {'name': 'Finalize Endpoint Round',
+                'vote_method': 'yesno',
+                'quorum': 1,
+                'deadline_date': '2016-10-15T00:00:00',
+                'jurors': [u'Slaporte']}
+    resp = fetch('coordinator: add round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 rnd_data,
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    resp = fetch('coordinator: import entries',
+                 '/admin/round/%s/import' % round_id,
+                 {'import_method': 'category',
+                  'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+                 as_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: activate round',
+                 '/admin/round/%s/activate' % round_id,
+                 {'post': True},
+                 as_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: finalize round',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'post': True},
+                 as_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: get round details',
+                 '/admin/round/%s' % round_id,
+                 as_user='LilyOfTheWest')
+    assert resp['data']['status'] == 'finalized'
+    assert resp['data']['close_date'] is not None
+    assert 'final_threshold' not in resp['data']['config']
+
+    resp = fetch('coordinator: get finalize_round audit logs',
+                 '/admin/campaign/%s/audit?action=finalize_round' % campaign_id,
+                 as_user='LilyOfTheWest')
+    matching_logs = [log for log in resp['data'] if log['round_id'] == round_id]
+    assert len(matching_logs) == 1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@
 tox<3.15.0
 Fabric3
 coverage==5.0.2
-pytest==4.6.9
+pytest>=7,<9
+responses>=0.25.0


### PR DESCRIPTION
Fixes #462.

The `finalize_round` endpoint was bypassing the standard `DAO.close_round` logic and mutating row state directly. This skipped writing the `close_date` and audit logs. I've routed it properly through the DAO so the lifecycle hooks trigger as expected.