### PR TITLE
fix(rounds): show and inherit DQ flags when creating new rounds

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -1,12 +1,27 @@
 <template>
   <div class="juror-campaign-round-card">
     <div class="round-header">
-      <thumbs-up-down v-if="formData.vote_method === 'yesno'" class="juror-campaign-round-icon" :size="36"
-        fillColor="white" style="background-color: grey" />
-      <star-outline v-if="formData.vote_method === 'rating'" class="juror-campaign-round-icon" :size="36"
-        fillColor="white" style="background-color: grey" />
-      <sort v-if="formData.vote_method === 'ranking'" class="juror-campaign-round-icon" :size="36" fillColor="white"
-        style="background-color: grey" />
+      <thumbs-up-down
+        v-if="formData.vote_method === 'yesno'"
+        class="juror-campaign-round-icon"
+        :size="36"
+        fillColor="white"
+        style="background-color: grey"
+      />
+      <star-outline
+        v-if="formData.vote_method === 'rating'"
+        class="juror-campaign-round-icon"
+        :size="36"
+        fillColor="white"
+        style="background-color: grey"
+      />
+      <sort
+        v-if="formData.vote_method === 'ranking'"
+        class="juror-campaign-round-icon"
+        :size="36"
+        fillColor="white"
+        style="background-color: grey"
+      />
       <div class="round-info">
         <h2>{{ formData.name }}</h2>
         <p>{{ $t(getVotingName(formData.vote_method)) }}</p>
@@ -24,22 +39,35 @@
               </cdx-field>
               <div class="flex-row">
                 <cdx-field>
-                  <date-picker v-model:value="formData.deadline_date" type="date" format="YYYY-MM-DD"
-                    placeholder="YYYY-MM-DD" value-type="format"></date-picker>
+                  <date-picker
+                    v-model:value="formData.deadline_date"
+                    type="date"
+                    format="YYYY-MM-DD"
+                    placeholder="YYYY-MM-DD"
+                    value-type="format"
+                  ></date-picker>
                   <template #label>{{ $t('montage-round-deadline') }}</template>
                 </cdx-field>
                 <cdx-field>
-                  <cdx-select v-model:selected="formData.vote_method" :menu-items="voteMethods.map((method) => ({
-                    label: $t(getVotingName(method)),
-                    value: method
-                  }))
-                    " />
+                  <cdx-select
+                    v-model:selected="formData.vote_method"
+                    :menu-items="
+                      voteMethods.map((method) => ({
+                        label: $t(getVotingName(method)),
+                        value: method
+                      }))
+                    "
+                  />
                   <template #label>{{ $t('montage-round-vote-method') }}</template>
                 </cdx-field>
               </div>
               <cdx-field v-if="roundIndex === 0">
-                <cdx-radio v-for="source in importSourceMethods" :key="'radio-' + source.value"
-                  v-model="selectedImportSource" :input-value="source.value">
+                <cdx-radio
+                  v-for="source in importSourceMethods"
+                  :key="'radio-' + source.value"
+                  v-model="selectedImportSource"
+                  :input-value="source.value"
+                >
                   {{ source.label }}
                 </cdx-radio>
                 <template #label>{{ $t('montage-round-source') }}</template>
@@ -56,8 +84,13 @@
                 </template>
               </cdx-field>
               <cdx-field v-if="roundIndex === 0 && selectedImportSource === 'category'">
-                <cdx-lookup data-testid="montage-round-category" v-model:selected="importSourceValue.category" :menu-items="categoryOptions"
-                  :placeholder="$t('montage-round-category-placeholder')" @input="searchCategory">
+                <cdx-lookup
+                  data-testid="montage-round-category"
+                  v-model:selected="importSourceValue.category"
+                  :menu-items="categoryOptions"
+                  :placeholder="$t('montage-round-category-placeholder')"
+                  @input="searchCategory"
+                >
                   <template #label>{{ $t('montage-round-category-label') }}</template>
                   <template #no-results>{{ $t('montage-round-no-category') }}</template>
                 </cdx-lookup>
@@ -75,8 +108,12 @@
                 <template #label>{{ $t('montage-directions') }}</template>
               </cdx-field>
               <cdx-field v-if="roundIndex === 0">
-                <cdx-radio v-for="source in showStatsOptions" :key="'show_stats-' + source.value"
-                  v-model="formData.show_stats" :input-value="source.value">
+                <cdx-radio
+                  v-for="source in showStatsOptions"
+                  :key="'show_stats-' + source.value"
+                  v-model="formData.show_stats"
+                  :input-value="source.value"
+                >
                   {{ source.label }}
                 </cdx-radio>
                 <template #label>{{ $t('montage-label-round-stats') }}</template>
@@ -92,25 +129,36 @@
                 </template>
               </cdx-field>
               <cdx-field>
-                <UserList :users="formData.jurors" @update:selectedUsers="formData.jurors = $event" data-testid="userlist-search" />
+                <UserList
+                  :users="formData.jurors"
+                  @update:selectedUsers="formData.jurors = $event"
+                  data-testid="userlist-search"
+                />
                 <template #label>{{ $t('montage-label-round-jurors') }}</template>
                 <template #help-text>
                   <p>{{ $t('montage-round-jurors-description') }}</p>
                 </template>
               </cdx-field>
               <cdx-field v-if="thresholds">
-                <cdx-select v-model:selected="formData.threshold" :menu-items="thresholdOptions"
-                  :default-label="$t('montage-round-threshold-default')" />
+                <cdx-select
+                  v-model:selected="formData.threshold"
+                  :menu-items="thresholdOptions"
+                  :default-label="$t('montage-round-threshold-default')"
+                />
                 <template #label>{{ $t('montage-round-threshold') }}</template>
                 <template #description>
                   <p>{{ $t('montage-round-threshold-description') }}</p>
                 </template>
               </cdx-field>
             </div>
-            <div class="form-right" v-if="roundIndex === 0">
+            <div class="form-right">
               <p>{{ $t('montage-round-file-setting') }}</p>
               <cdx-field>
-                <cdx-checkbox v-for="key in fileSettingsOptions" :key="key" v-model="formData.config[key]">
+                <cdx-checkbox
+                  v-for="key in fileSettingsOptions"
+                  :key="key"
+                  v-model="formData.config[key]"
+                >
                   {{ $t('montage-round-' + key.replaceAll('_', '-')) }}
                 </cdx-checkbox>
               </cdx-field>
@@ -121,10 +169,19 @@
             </div>
           </div>
           <div class="button-group">
-            <cdx-button :disabled="isLoading" action="progressive" weight="primary" @click="submitRound()">
+            <cdx-button
+              :disabled="isLoading"
+              action="progressive"
+              weight="primary"
+              @click="submitRound()"
+            >
               <check class="icon-small" /> {{ $t('montage-round-add') }}
             </cdx-button>
-            <cdx-button action="destructive" @click="cancelRound()" data-testid="cancel-round-button">
+            <cdx-button
+              action="destructive"
+              @click="cancelRound()"
+              data-testid="cancel-round-button"
+            >
               <close class="icon-small" /> {{ $t('montage-btn-cancel') }}
             </cdx-button>
           </div>
@@ -180,6 +237,7 @@ const campaignId = route.params.id.split('-')[0]
 
 const voteMethods = ['yesno', 'rating', 'ranking']
 const fileSettingsOptions = [
+  'dq_by_filetype',
   'dq_by_uploader',
   'dq_by_resolution',
   'dq_by_upload_date',
@@ -206,6 +264,38 @@ const thresholds = ref(null)
 const thresholdOptions = ref(null)
 const isLoading = ref(false)
 
+const defaultConfig = {
+  dq_by_filetype: true,
+  dq_by_resolution: false,
+  min_resolution: 2000000,
+  dq_by_uploader: false,
+  dq_by_upload_date: true,
+  dq_coords: true,
+  dq_maintainers: true,
+  dq_organizers: true,
+  show_filename: true,
+  show_link: true,
+  show_resolution: true
+}
+
+const isNonEmptyConfig = (config) =>
+  config && typeof config === 'object' && !Array.isArray(config) && Object.keys(config).length > 0
+
+const getInheritedRoundConfig = () => {
+  if (roundIndex === 0) {
+    return { ...defaultConfig }
+  }
+
+  const sourceRound = [...props.rounds]
+    .reverse()
+    .find((round) => isNonEmptyConfig(round.config))
+
+  return {
+    ...defaultConfig,
+    ...((sourceRound && sourceRound.config) || {})
+  }
+}
+
 const formData = ref({
   name: `Round ${roundIndex + 1}`,
   vote_method: roundIndex !== 0 && roundIndex < 3 ? voteMethods[roundIndex] : 'yesno',
@@ -215,18 +305,7 @@ const formData = ref({
   threshold: null,
   jurors: roundIndex !== 0 ? prevRound.jurors.map((juror) => juror.username) : [],
   directions: '',
-  config: {
-    dq_by_resolution: false,
-    min_resolution: 2000000,
-    dq_by_uploader: true,
-    dq_by_upload_date: false,
-    dq_coords: false,
-    dq_maintainers: false,
-    dq_organizers: false,
-    show_filename: false,
-    show_link: false,
-    show_resolution: false
-  }
+  config: getInheritedRoundConfig()
 })
 
 // States for import source
@@ -257,18 +336,15 @@ const submitRound = () => {
   if (!formData.value.deadline_date) {
     alertService.error({
       message: $t('montage-required-voting-deadline')
-    });
-    return;
+    })
+    return
   }
 
-  if (
-  !formData.value.name ||
-  (formData.value.quorum > 0 && formData.value.jurors.length === 0)
-) {
+  if (!formData.value.name || (formData.value.quorum > 0 && formData.value.jurors.length === 0)) {
     alertService.error({
       message: $t('montage-required-fill-inputs')
-    });
-    return;
+    })
+    return
   }
 
   // Check if the round is the first round
@@ -314,11 +390,13 @@ const submitRound = () => {
         vote_method: formData.value.vote_method,
         quorum: formData.value.quorum,
         deadline_date: formData.value.deadline_date + 'T00:00:00',
-        jurors: formData.value.jurors
+        jurors: formData.value.jurors,
+        config: formData.value.config
       },
       threshold: formData.value.threshold
     }
 
+    isLoading.value = true
     adminService
       .advanceRound(prevRound.id, payload)
       .then(() => {
@@ -327,6 +405,7 @@ const submitRound = () => {
       })
       .catch(alertService.error)
       .finally(() => {
+        isLoading.value = false
         emit('reload-campaign-state')
         emit('update:showAddRoundForm', false)
       })

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -310,11 +310,20 @@ def test_home_client(base_client, api_client):
                 as_user='LilyOfTheWest')
 
     config = rnd['data']['config']
+    dq_config_keys = ['dq_by_upload_date',
+                      'dq_by_resolution',
+                      'dq_by_uploader',
+                      'dq_by_filetype',
+                      'dq_coords',
+                      'dq_organizers',
+                      'dq_maintainers']
+    round_1_dq_config = dict((k, config.get(k)) for k in dq_config_keys)
     config['show_filename'] = False
+    round_1_full_config = dict(config)
 
     resp = fetch('coordinator: edit round config',
                  '/admin/round/%s/edit' % round_id,
-                 {'config': config},
+                 {'config': round_1_full_config},
                  as_user='LilyOfTheWest')
 
     data = {'import_method': 'category',
@@ -566,6 +575,9 @@ def test_home_client(base_client, api_client):
                  '/admin/round/%s/preview_results' % round_id,
                  as_user='LilyOfTheWest')
 
+    round_2_submit_config = dict(round_1_full_config)
+    round_2_submit_config['min_resolution'] = 1500000
+
     rnd_data = {'name': 'Test advance to rating round',
                 'vote_method': 'rating',
                 'quorum': 3,
@@ -573,7 +585,8 @@ def test_home_client(base_client, api_client):
                 'jurors': [u'Slaporte',
                            u'Effeietsanders',
                            u'Jean-Frédéric',
-                           u'LilyOfTheWest']}
+                           u'LilyOfTheWest'],
+                'config': dict(round_2_submit_config)}
 
     resp = fetch('coordinator: close round, loading results into a new round',
                  '/admin/round/%s/advance' % round_id,
@@ -581,6 +594,43 @@ def test_home_client(base_client, api_client):
                  as_user='LilyOfTheWest')
 
     rnd_2_id = resp['data']['id']
+
+    rnd_2_details = fetch('coordinator: verify round 2 inherited round 1 dq flags',
+                          '/admin/round/%s' % rnd_2_id,
+                          as_user='LilyOfTheWest')
+    rnd_2_config = rnd_2_details['data']['config']
+    round_2_dq_config = dict((k, rnd_2_config.get(k)) for k in dq_config_keys)
+    assert round_2_dq_config == round_1_dq_config
+    assert rnd_2_config.get('min_resolution') == round_2_submit_config.get('min_resolution')
+    assert rnd_2_config.get('show_filename') == round_1_full_config.get('show_filename')
+
+    round_2_updated_dq_config = dict(round_2_dq_config)
+    round_2_updated_dq_config.update({'dq_by_resolution': True,
+                                      'dq_by_uploader': False,
+                                      'dq_coords': False,
+                                      'dq_maintainers': False})
+    rnd_2_config.update(round_2_updated_dq_config)
+    resp = fetch('coordinator: edit round 2 dq flags',
+                 '/admin/round/%s/edit' % rnd_2_id,
+                 {'config': rnd_2_config},
+                 as_user='LilyOfTheWest')
+
+    rnd_2_details = fetch('coordinator: verify round 2 dq flags persisted after edit',
+                          '/admin/round/%s' % rnd_2_id,
+                          as_user='LilyOfTheWest')
+    rnd_2_config = rnd_2_details['data']['config']
+    round_2_saved_dq_config = dict((k, rnd_2_config.get(k)) for k in dq_config_keys)
+    assert round_2_saved_dq_config == round_2_updated_dq_config
+
+    resp = fetch('coordinator: clear round 2 config to simulate empty config',
+                 '/admin/round/%s/edit' % rnd_2_id,
+                 {'config': {}},
+                 as_user='LilyOfTheWest')
+
+    rnd_2_details = fetch('coordinator: verify round 2 config is empty',
+                          '/admin/round/%s' % rnd_2_id,
+                          as_user='LilyOfTheWest')
+    assert rnd_2_details['data']['config'] == {}
 
     # TODO: test getting a csv of final round results needs more instrumentation
     print('>> downloading results')
@@ -620,12 +670,21 @@ def test_home_client(base_client, api_client):
                 'jurors': [u'Slaporte',
                            u'Effeietsanders',
                            u'Jean-Frédéric',
-                           u'MahmoudHashemi']}
+                           u'MahmoudHashemi'],
+                'config': dict(round_1_full_config)}
     resp = fetch('coordinator: advance to round 3',
                  '/admin/round/%s/advance' % rnd_2_id,
                  {'next_round': rnd_data, 'threshold': cur_thresh},
                  as_user='LilyOfTheWest')
     rnd_3_id = resp['data']['id']
+
+    rnd_3_details = fetch('coordinator: verify round 3 inherited round 1 config after round 2 was empty',
+                          '/admin/round/%s' % rnd_3_id,
+                          as_user='LilyOfTheWest')
+    rnd_3_config = rnd_3_details['data']['config']
+    round_3_dq_config = dict((k, rnd_3_config.get(k)) for k in dq_config_keys)
+    assert round_3_dq_config == round_1_dq_config
+    assert rnd_3_config.get('show_filename') == round_1_full_config.get('show_filename')
 
     resp = fetch('coordinator: preview empty ranking round (should fail gracefully)',
                  '/admin/round/%s/preview_results' % rnd_3_id,
@@ -803,6 +862,72 @@ def test_home_client(base_client, api_client):
                  as_user='LilyOfTheWest')
 
     pprint(resp['data'])
+
+    resp = fetch('get default series for default config fallback scenario',
+                 '/series')
+    fallback_series_id = resp['data'][0]['id']
+
+    fallback_campaign_data = {'name': 'Default Config Fallback Campaign',
+                              'coordinators': [u'LilyOfTheWest',
+                                               u'Slaporte',
+                                               u'Yarl'],
+                              'close_date': '2015-11-01 17:00:00',
+                              'url': 'http://hatnote.com',
+                              'series_id': fallback_series_id}
+    resp = fetch('organizer: create campaign for default config fallback scenario',
+                 '/admin/add_campaign',
+                 fallback_campaign_data,
+                 as_user='Yarl')
+
+    resp = fetch('coordinator: get admin view for default config fallback scenario',
+                 '/admin', as_user='LilyOfTheWest')
+    fallback_campaign_id = resp['data'][-1]['id']
+
+    fallback_round_1_data = {'name': 'Fallback yes/no round',
+                             'vote_method': 'yesno',
+                             'quorum': 1,
+                             'deadline_date': "2016-11-01T00:00:00",
+                             'jurors': [u'Slaporte']}
+    resp = fetch('coordinator: add fallback round without explicit config',
+                 '/admin/campaign/%s/add_round' % fallback_campaign_id,
+                 fallback_round_1_data,
+                 as_user='LilyOfTheWest')
+    fallback_round_1_id = resp['data']['id']
+
+    fallback_round_1_details = fetch('coordinator: read fallback round 1 config',
+                                     '/admin/round/%s' % fallback_round_1_id,
+                                     as_user='LilyOfTheWest')
+    fallback_round_1_config = fallback_round_1_details['data']['config']
+    assert fallback_round_1_config.get('dq_by_upload_date') is True
+    assert fallback_round_1_config.get('dq_by_resolution') is False
+
+    resp = fetch('coordinator: import fallback round entries',
+                 '/admin/round/%s/import' % fallback_round_1_id,
+                 {'import_method': 'category',
+                  'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+                 as_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: activate fallback round',
+                 '/admin/round/%s/activate' % fallback_round_1_id,
+                 {'post': True},
+                 as_user='LilyOfTheWest')
+
+    submit_ratings(api_client, fallback_round_1_id, coord_user='LilyOfTheWest')
+
+    fallback_round_2_data = {'name': 'Fallback rating round',
+                             'vote_method': 'rating',
+                             'quorum': 1,
+                             'deadline_date': "2016-11-03T00:00:00",
+                             'jurors': [u'Slaporte'],
+                             'config': dict(fallback_round_1_config)}
+    resp = fetch('coordinator: advance fallback round using default config',
+                 '/admin/round/%s/advance' % fallback_round_1_id,
+                 {'next_round': fallback_round_2_data,
+                  'threshold': 0.0},
+                 as_user='LilyOfTheWest')
+    fallback_round_2_config = resp['data']['config']
+    for key, value in fallback_round_1_config.items():
+        assert fallback_round_2_config.get(key) == value
 
 
     # maintainer stuff


### PR DESCRIPTION
**Description**  
This PR ensures the disqualification (DQ) flags panel is always visible when creating any round, inherits settings from the previous round for Round 2 and beyond, sends the correct config to the backend, and adds the missing `dq_by_filetype` option.

**Solution**  
- Always render DQ flags panel for all rounds  
- Inherit config from previous round for new rounds  
- Include config in `advance_round` API payload  
- Add `dq_by_filetype` to file settings

Fixes #347 

**How to Test**  
1. Create Round 1: DQ flags panel is visible and editable  
2. Create Round 2+: DQ flags panel is visible, pre-filled with previous values, and editable  
3. Confirm new round uses selected DQ settings

**Screenshots**  
|Before|After|
|----|----|
|<img width="1438" height="900" alt="Screenshot 2026-04-04 at 3 36 14 PM" src="https://github.com/user-attachments/assets/91433b2f-c512-4aac-8550-b4505cd33c56" />|<img width="1438" height="900" alt="Screenshot 2026-04-04 at 3 36 57 PM" src="https://github.com/user-attachments/assets/6eb93b20-1465-4999-bc46-0fd204012e0f" />

