### PR TITLE
Fix categorylinks query for MediaWiki link target normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,7 @@ cypress/screenshots/
 cypress/videos/
 
 .vscode/
+
+# Claude Code
+.claude/
+tmp/

--- a/montage/labs.py
+++ b/montage/labs.py
@@ -72,7 +72,9 @@ def get_files(category_name):
         AND page_title = img_name
         JOIN categorylinks ON cl_from = page_id
         AND cl_type = 'file'
-        AND cl_to = %s
+        JOIN linktarget ON cl_target_id = lt_id
+        AND lt_namespace = 14
+        AND lt_title = %s
         GROUP BY img_name
         ORDER BY oi_timestamp ASC;
     '''.format(cols=', '.join(IMAGE_COLS))


### PR DESCRIPTION
## Summary

- **labs.py**: replace `cl_to` with a join on the new `linktarget` table (`cl_target_id = lt_id AND lt_namespace = 14 AND lt_title = %s`), following Wikimedia's link target normalization schema change (2022-2023)

## Notes

- The `cl_to` column in `categorylinks` was replaced by `cl_target_id` (FK to `linktarget`) on Wikimedia replicas. This broke category import on Toolforge.
- The `xfail` marks originally in this PR have been dropped — master now has properly mocked tests covering the same cases.
- Verified working on montage-beta: category import completes successfully.

## Test plan

- [x] Deploy to montage-beta and verify category import works
- [x] xfail marks removed (superseded by mocked tests in master)
- [x] CI passes (6/6 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)