### PR TITLE
fix(auth): surface 401 session expiry to frontend with user notification

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -48,6 +48,12 @@ const addInterceptors = (instance) => {
       const loadingStore = useLoadingStore()
       loadingStore.setLoading(false)
 
+      if (error.response && error.response.status === 401) {
+        // Auth failure - could be session expired
+        // Hard redirect to home to trigger re-auth check
+        window.location.href = '#/'
+      }
+
       return Promise.reject(error)
     }
   )

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -20,6 +20,8 @@ const apiCommons = axios.create({
   }
 })
 
+import AlertService from './alertService'
+
 const addInterceptors = (instance) => {
   instance.interceptors.request.use(
     (config) => {
@@ -51,7 +53,10 @@ const addInterceptors = (instance) => {
       if (error.response && error.response.status === 401) {
         // Auth failure - could be session expired
         // Hard redirect to home to trigger re-auth check
-        window.location.href = '#/'
+        AlertService.error({ message: 'Session expired. Please log in again.' })
+        setTimeout(() => {
+          window.location.href = '#/'
+        }, 2000)
       }
 
       return Promise.reject(error)

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { useLoadingStore } from '@/stores/loading'
+import alertService from './alertService'
 
 // Create Axios instance for Backend API
 const apiBackend = axios.create({
@@ -11,7 +12,7 @@ const apiBackend = axios.create({
   withCredentials: true
 })
 
-// Create Axios instance for Commons API
+// Create Axios instance for Commons API (no auth interceptor — Commons uses its own auth)
 const apiCommons = axios.create({
   baseURL: 'https://commons.wikimedia.org/w/api.php',
   headers: {
@@ -20,51 +21,64 @@ const apiCommons = axios.create({
   }
 })
 
-import AlertService from './alertService'
-
-const addInterceptors = (instance) => {
+const addLoadingInterceptors = (instance) => {
   instance.interceptors.request.use(
     (config) => {
       const loadingStore = useLoadingStore()
       loadingStore.setLoading(true)
-
       return config
     },
     (error) => {
       const loadingStore = useLoadingStore()
       loadingStore.setLoading(false)
-
       return Promise.reject(error)
     }
   )
 
-  // Response Interceptor
   instance.interceptors.response.use(
     (response) => {
       const loadingStore = useLoadingStore()
       loadingStore.setLoading(false)
-
       return response['data']
     },
     (error) => {
       const loadingStore = useLoadingStore()
       loadingStore.setLoading(false)
-
-      if (error.response && error.response.status === 401) {
-        // Auth failure - could be session expired
-        // Hard redirect to home to trigger re-auth check
-        AlertService.error({ message: 'Session expired. Please log in again.' })
-        setTimeout(() => {
-          window.location.href = '#/'
-        }, 2000)
-      }
-
       return Promise.reject(error)
     }
   )
 }
 
-addInterceptors(apiBackend)
-addInterceptors(apiCommons)
+// Separate 401 session-expiry interceptor — applied only to apiBackend.
+// Commons API 401s are not Montage session failures and must not trigger a redirect.
+const addAuthInterceptor = (instance) => {
+  instance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      if (error.response && error.response.status === 401) {
+        // Extract the backend's error message if available, fall back to a generic one.
+        const backendErrors = error.response?.data?.errors
+        const message =
+          Array.isArray(backendErrors) && backendErrors.length > 0
+            ? backendErrors[0]
+            : 'Session expired. Please log in again.'
+
+        // Show the message before any navigation so the user understands why
+        // they're being redirected and does not lose context of what they were doing.
+        alertService.error(message)
+
+        // Delay redirect to give the user time to read the error toast.
+        setTimeout(() => {
+          window.location.href = '#/'
+        }, 2000)
+      }
+      return Promise.reject(error)
+    }
+  )
+}
+
+addLoadingInterceptors(apiBackend)
+addLoadingInterceptors(apiCommons)
+addAuthInterceptor(apiBackend)   // session 401 handling — backend only
 
 export { apiBackend, apiCommons }

--- a/montage/mw/__init__.py
+++ b/montage/mw/__init__.py
@@ -136,16 +136,19 @@ class UserMiddleware(Middleware):
                 else:
                     if ep_is_public:
                         return next(user=None, user_dao=None)
+                    # @ayushshukla1807: we must explicitly return 401 here so MessageMiddleware
+                    # doesn't catch the empty dict and wrap it in a silent 200 OK. 
+                    # This is what breaks the Axios catch loop in Issue #116.
                     err = 'invalid cookie userid, try logging in again.'
                     response_dict['errors'].append(err)
-                    return {}
+                    return {'_status_code': 401}
 
         user = rdb_session.query(User).filter(User.id == userid).first()
 
         if user is None and not ep_is_public:
             err = 'unknown cookie userid, try logging in again'
             response_dict['errors'].append(err)
-            return {}
+            return {'_status_code': 401}
 
         superuser = config.get('superuser')
         superusers = config.get('superusers', [superuser] if superuser else [])
@@ -158,7 +161,7 @@ class UserMiddleware(Middleware):
             if not user:
                 err = 'unknown su_to user %r' % (su_to,)
                 response_dict['errors'].append(err)
-                return {}
+                return {'_status_code': 401}
 
         now = datetime.datetime.utcnow()
         last_minute = now - datetime.timedelta(seconds=60)

--- a/montage/mw/__init__.py
+++ b/montage/mw/__init__.py
@@ -136,9 +136,6 @@ class UserMiddleware(Middleware):
                 else:
                     if ep_is_public:
                         return next(user=None, user_dao=None)
-                    # @ayushshukla1807: we must explicitly return 401 here so MessageMiddleware
-                    # doesn't catch the empty dict and wrap it in a silent 200 OK. 
-                    # This is what breaks the Axios catch loop in Issue #116.
                     err = 'invalid cookie userid, try logging in again.'
                     response_dict['errors'].append(err)
                     return {'_status_code': 401}

--- a/montage/mw/__init__.py
+++ b/montage/mw/__init__.py
@@ -158,7 +158,7 @@ class UserMiddleware(Middleware):
             if not user:
                 err = 'unknown su_to user %r' % (su_to,)
                 response_dict['errors'].append(err)
-                return {'_status_code': 401}
+                return {'_status_code': 400}
 
         now = datetime.datetime.utcnow()
         last_minute = now - datetime.timedelta(seconds=60)


### PR DESCRIPTION
Fixes the session dropping issue mentioned in #116.

If a user's session expired during a vote loop, the `UserMiddleware` dropped the cookie and returned an empty dict. The backend just forwarded a HTTP 200 with an error string attached, which meant the frontend `.catch()` block never triggered. The UI would move on like normal while the vote was lost.

I've updated the middleware to throw an explicit 401 when the cookie is invalid, so the frontend correctly halts and prompts a re-login.