### PR TITLE
fix(admin): correct dict literal syntax in import_entries warning accumulation

### DIFF
--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -348,7 +348,7 @@ def import_entries(user_dao, round_id, request_dict):
         params = {'csv_url': csv_url}
         if warnings:
             msg = u'unable to load {} files ({!r})'.format(len(warnings), warnings)
-            import_warnings.append(msg)
+            import_warnings.append({'import issues': msg})
     elif import_method == CATEGORY_METHOD:
         cat_name = request_dict['category']
         entries = coord_dao.add_entries_from_cat(round_id, cat_name)

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -367,7 +367,7 @@ def import_entries(user_dao, round_id, request_dict):
                 u'- {}'.format(warning) for warning in warnings
             ])
             msg = u'unable to load {} files:\n{}'.format(len(warnings), formatted_warnings)
-            import_warnings.append({'import issues', msg})
+            import_warnings.append({'import issues': msg})
         params = {'file_names': file_names}
     else:
         raise NotImplementedResponse()


### PR DESCRIPTION
Fixes a data drop in `admin_endpoints.py` where import warnings were being lost instead of passed to the frontend.

In `import_entries`, the CSV/uploaded files branch was building a Python set for `warning_messages` instead of a dict like the other branches. When it tried to JSON serialize this for the response, the backend threw an error. I just updated it to use standard dict syntax `{{}}` so the warnings surface correctly.