### PR TITLE
fix(admin): finalize round via DAO close path

### DIFF
--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -14,8 +14,7 @@ from .utils import (format_date,
                    NotImplementedResponse,
                    js_isoparse)
 
-from .rdb import (FINALIZED_STATUS,
-                 CoordinatorDAO,
+from .rdb import (CoordinatorDAO,
                  MaintainerDAO,
                  OrganizerDAO)
 
@@ -417,8 +416,7 @@ def pause_round(user_dao, round_id, request_dict):
 
 def finalize_round(user_dao, round_id, request_dict):
     coord_dao = CoordinatorDAO.from_round(user_dao, round_id)
-    rnd = coord_dao.get_round(round_id)
-    rnd.status = FINALIZED_STATUS
+    coord_dao.finalize_round(round_id)
 
     return {'status': 'success'}
 

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -1553,6 +1553,17 @@ class CoordinatorDAO(UserDAO):
 
         return
 
+    def finalize_round(self, round_id):
+        rnd = self.get_round(round_id)
+        rnd.close_date = datetime.datetime.utcnow()
+        rnd.status = FINALIZED_STATUS
+
+        msg = '%s finalized round "%s" (#%s)' % (self.user.username,
+                                                 rnd.name,
+                                                 rnd.id)
+        self.log_action('finalize_round', round=rnd, message=msg)
+        return rnd
+
     def add_entries_from_cat(self, round_id, cat_name):
         rnd = self.user_dao.get_round(round_id)
         if ENV_NAME == 'dev':

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -863,6 +863,65 @@ def test_multiple_jurors(api_client, mock_external_apis):
                  as_user='LilyOfTheWest')
 
 
+def test_finalize_round_sets_close_date_and_logs_action(api_client,
+                                                        mock_external_apis):
+    fetch = api_client.fetch
+
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    campaign_data = {'name': 'Finalize Round Regression Campaign',
+                     'coordinators': [u'LilyOfTheWest',
+                                      u'Yarl'],
+                     'close_date': '2015-10-01 17:00:00',
+                     'url': 'http://hatnote.com',
+                     'series_id': series_id}
+    resp = fetch('organizer: create campaign',
+                 '/admin/add_campaign',
+                 campaign_data,
+                 as_user='Yarl')
+    campaign_id = resp['data']['id']
+
+    rnd_data = {'name': 'Finalize Endpoint Round',
+                'vote_method': 'yesno',
+                'quorum': 1,
+                'deadline_date': '2016-10-15T00:00:00',
+                'jurors': [u'Slaporte']}
+    resp = fetch('coordinator: add round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 rnd_data,
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    resp = fetch('coordinator: import entries',
+                 '/admin/round/%s/import' % round_id,
+                 {'import_method': 'category',
+                  'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+                 as_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: activate round',
+                 '/admin/round/%s/activate' % round_id,
+                 {'post': True},
+                 as_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: finalize round',
+                 '/admin/round/%s/finalize' % round_id,
+                 {'post': True},
+                 as_user='LilyOfTheWest')
+
+    resp = fetch('coordinator: get round details',
+                 '/admin/round/%s' % round_id,
+                 as_user='LilyOfTheWest')
+    assert resp['data']['status'] == 'finalized'
+    assert resp['data']['close_date'] is not None
+
+    resp = fetch('coordinator: get finalize_round audit logs',
+                 '/admin/campaign/%s/audit?action=finalize_round' % campaign_id,
+                 as_user='LilyOfTheWest')
+    matching_logs = [log for log in resp['data'] if log['round_id'] == round_id]
+    assert len(matching_logs) == 1
+
+
 @script_log.wrap('critical', verbose=True)
 def submit_ratings(client, round_id, coord_user='Yarl'):
     """


### PR DESCRIPTION
### Description
The admin finalize round endpoint was directly mutating round status, which skipped round-close side effects. This change introduces a dedicated DAO close-round method and delegates the endpoint to it.

### Verification

* Full pytest suite run
* New regression test included and passing
* Manual Validation

Solution directly follows the feedback given in https://github.com/hatnote/montage/pull/463#issuecomment-4229386334

Closes #462 

### Screenshots of UI Validation
|Before Finalization|After Finaliation|
|---|---|
|<img width="1440" height="900" alt="Screenshot 2026-04-11 at 10 39 01 PM" src="https://github.com/user-attachments/assets/61f46940-86e9-42d4-a6fd-4c42737db641" />|<img width="1440" height="900" alt="Screenshot 2026-04-11 at 10 39 40 PM" src="https://github.com/user-attachments/assets/8e92a4a4-dddd-4e91-bfa9-64c4308a1b67" />|

