### PR TITLE
fix: remove voted items from local batch immediately to prevent reappearance in voting UI

### DIFF
--- a/frontend/src/components/Vote/VoteRating.vue
+++ b/frontend/src/components/Vote/VoteRating.vue
@@ -144,7 +144,16 @@
       </div>
     </div>
   </div>
-  <div class="voting-completed" v-if="round.status === 'active' && !images?.length">
+  <div
+    class="vote-batch-loading"
+    v-if="round.status === 'active' && isFetchingTasks && !images?.length"
+  >
+    <clip-loader size="80px" style="padding-top: 120px" />
+  </div>
+  <div
+    class="voting-completed"
+    v-if="round.status === 'active' && !isFetchingTasks && !images?.length"
+  >
     <div>
       <h3>{{ $t('montage-vote-all-done') }}</h3>
       <p class="greyed">
@@ -172,6 +181,7 @@ import jurorService from '@/services/jurorService'
 import { useRouter } from 'vue-router'
 import alertService from '@/services/alertService'
 import { getCommonsImageUrl } from '@/utils'
+import { getWrappedNextIndex, removeVotedFromQueue } from '@/utils/voteQueue'
 
 import CommonsImage from '@/components/CommonsImage.vue'
 import { CdxButton, CdxProgressBar } from '@wikimedia/codex'
@@ -193,12 +203,12 @@ const { t: $t } = useI18n()
 const router = useRouter()
 
 // States variables
-const counter = ref(0)
 const skips = ref(0)
 const imageLoading = ref(true)
 const voteContainer = ref(null)
 const showSidebar = ref(true)
 const imageCache = new Map()
+const isFetchingTasks = ref(false)
 const isLoading = ref(false)
 
 const props = defineProps({
@@ -242,25 +252,47 @@ const formattedDate = (timestamp) => {
 }
 
 function getNextImage() {
-  rating.value.currentIndex = (rating.value.currentIndex + 1) % images.value?.length
+  if (!images.value?.length) {
+    rating.value.current = null
+    rating.value.next = null
+    rating.value.currentIndex = 0
+    return
+  }
+  rating.value.currentIndex = getWrappedNextIndex(rating.value.currentIndex, images.value.length)
   rating.value.current = images.value[rating.value.currentIndex]
-  rating.value.next = images.value[(rating.value.currentIndex + 1) % images.value?.length]
+  rating.value.next =
+    images.value[getWrappedNextIndex(rating.value.currentIndex, images.value.length)]
+}
+
+function removeCurrentImage() {
+  const result = removeVotedFromQueue(images.value, rating.value.currentIndex)
+  images.value = result.queue
+  rating.value.currentIndex = result.currentIndex
+  rating.value.current = result.current
+  rating.value.next = result.next
 }
 
 function getTasks() {
-  return jurorService.getRoundTasks(props.round.id, skips.value).then((response) => {
-    images.value = response.data.tasks
-    rating.value.current = images.value?.[0]
-    rating.value.currentIndex = 0
-    rating.value.next = images.value?.[1] || null
+  isFetchingTasks.value = true
+  return jurorService
+    .getRoundTasks(props.round.id, skips.value)
+    .then((response) => {
+      images.value = response.data.tasks
+      stats.value = response.data.stats
+      rating.value.current = images.value?.[0]
+      rating.value.currentIndex = 0
+      rating.value.next = images.value?.[1] || null
 
-    // Preload the next 10 images
-    for (let i = 0; i < 10 && i < images.value.length; i++) {
-      const img = new Image()
-      img.src = getCommonsImageUrl(images.value[i])
-      imageCache.set(images.value[i].entry.id, img)
-    }
-  })
+      // Preload the next 10 images
+      for (let i = 0; i < 10 && i < images.value.length; i++) {
+        const img = new Image()
+        img.src = getCommonsImageUrl(images.value[i])
+        imageCache.set(images.value[i].entry.id, img)
+      }
+    })
+    .finally(() => {
+      isFetchingTasks.value = false
+    })
 }
 
 function setRate(rate) {
@@ -275,16 +307,14 @@ function setRate(rate) {
         ratings: [{ task_id: rating.value.current.id, value: val }]
       })
       .then(() => {
+        removeCurrentImage()
         stats.value.total_open_tasks -= 1
         if (stats.value.total_open_tasks <= 10) {
           skips.value = 0
         }
-        if (counter.value === 4 || !stats.value.total_open_tasks) {
-          counter.value = 0
-          getTasks()
-        } else {
-          counter.value += 1
-          getNextImage()
+
+        if (!rating.value.current) {
+          return getTasks()
         }
       })
       .catch(alertService.error)
@@ -300,7 +330,7 @@ function setRate(rate) {
         if (rating.value.currentIndex < images.value.length - 1) {
           getNextImage()
         } else {
-          getTasks()
+          return getTasks()
         }
       })
       .catch(alertService.error)
@@ -429,6 +459,13 @@ watch(voteContainer, () => {
 
 .vote-container:focus {
   outline: none;
+}
+
+.vote-batch-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 156.5px);
 }
 
 .vote-image-container {

--- a/frontend/src/components/Vote/VoteYesNo.vue
+++ b/frontend/src/components/Vote/VoteYesNo.vue
@@ -148,7 +148,16 @@
       </div>
     </div>
   </div>
-  <div class="voting-completed" v-if="round.status === 'active' && !images?.length">
+  <div
+    class="vote-batch-loading"
+    v-if="round.status === 'active' && isFetchingTasks && !images?.length"
+  >
+    <clip-loader size="80px" style="padding-top: 120px" />
+  </div>
+  <div
+    class="voting-completed"
+    v-if="round.status === 'active' && !isFetchingTasks && !images?.length"
+  >
     <div>
       <h3>{{ $t('montage-vote-all-done') }}</h3>
       <p class="greyed">
@@ -176,6 +185,7 @@ import jurorService from '@/services/jurorService'
 import { useRouter } from 'vue-router'
 import alertService from '@/services/alertService'
 import { getCommonsImageUrl } from '@/utils'
+import { getWrappedNextIndex, removeVotedFromQueue } from '@/utils/voteQueue'
 
 import CommonsImage from '@/components/CommonsImage.vue'
 import { CdxButton, CdxProgressBar } from '@wikimedia/codex'
@@ -198,12 +208,12 @@ const { t: $t } = useI18n()
 const router = useRouter()
 
 // States variables
-const counter = ref(0)
 const skips = ref(0)
 const imageLoading = ref(true)
 const voteContainer = ref(null)
 const showSidebar = ref(true)
 const imageCache = new Map()
+const isFetchingTasks = ref(false)
 
 const props = defineProps({
   round: Object,
@@ -247,25 +257,47 @@ const formattedDate = (timestamp) => {
 }
 
 const getNextImage = () => {
-  rating.value.currentIndex = (rating.value.currentIndex + 1) % images.value?.length
+  if (!images.value?.length) {
+    rating.value.current = null
+    rating.value.next = null
+    rating.value.currentIndex = 0
+    return
+  }
+  rating.value.currentIndex = getWrappedNextIndex(rating.value.currentIndex, images.value.length)
   rating.value.current = images.value[rating.value.currentIndex]
-  rating.value.next = images.value[(rating.value.currentIndex + 1) % images.value?.length]
+  rating.value.next =
+    images.value[getWrappedNextIndex(rating.value.currentIndex, images.value.length)]
+}
+
+const removeCurrentImage = () => {
+  const result = removeVotedFromQueue(images.value, rating.value.currentIndex)
+  images.value = result.queue
+  rating.value.currentIndex = result.currentIndex
+  rating.value.current = result.current
+  rating.value.next = result.next
 }
 
 const getTasks = () => {
-  return jurorService.getRoundTasks(props.round.id, skips.value).then((response) => {
-    images.value = response.data.tasks
-    rating.value.current = images.value?.[0]
-    rating.value.currentIndex = 0
-    rating.value.next = images.value?.[1] || null
+  isFetchingTasks.value = true
+  return jurorService
+    .getRoundTasks(props.round.id, skips.value)
+    .then((response) => {
+      images.value = response.data.tasks
+      stats.value = response.data.stats
+      rating.value.current = images.value?.[0]
+      rating.value.currentIndex = 0
+      rating.value.next = images.value?.[1] || null
 
-    // Preload the next 10 images
-    for (let i = 0; i < 10 && i < images.value.length; i++) {
-      const img = new Image()
-      img.src = getCommonsImageUrl(images.value[i])
-      imageCache.set(images.value[i].entry.id, img)
-    }
-  })
+      // Preload the next 10 images
+      for (let i = 0; i < 10 && i < images.value.length; i++) {
+        const img = new Image()
+        img.src = getCommonsImageUrl(images.value[i])
+        imageCache.set(images.value[i].entry.id, img)
+      }
+    })
+    .finally(() => {
+      isFetchingTasks.value = false
+    })
 }
 
 function setRate(rate) {
@@ -280,16 +312,14 @@ function setRate(rate) {
         ratings: [{ task_id: rating.value.current.id, value: val }]
       })
       .then(() => {
+        removeCurrentImage()
         stats.value.total_open_tasks -= 1
         if (stats.value.total_open_tasks <= 10) {
           skips.value = 0
         }
-        if (counter.value === 4 || !stats.value.total_open_tasks) {
-          counter.value = 0
-          getTasks()
-        } else {
-          counter.value += 1
-          getNextImage()
+
+        if (!rating.value.current) {
+          return getTasks()
         }
       })
       .catch(alertService.error)
@@ -305,7 +335,7 @@ function setRate(rate) {
         if (rating.value.currentIndex < images.value.length - 1) {
           getNextImage()
         } else {
-          getTasks()
+          return getTasks()
         }
       })
       .catch(alertService.error)
@@ -436,6 +466,13 @@ watch(voteContainer, () => {
 
 .vote-container:focus {
   outline: none;
+}
+
+.vote-batch-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 156.5px);
 }
 
 .vote-image-container {

--- a/frontend/src/utils/voteQueue.js
+++ b/frontend/src/utils/voteQueue.js
@@ -1,0 +1,37 @@
+export function getWrappedNextIndex(currentIndex, total) {
+  if (!total) {
+    return 0
+  }
+  return (currentIndex + 1) % total
+}
+
+export function removeVotedFromQueue(items, currentIndex) {
+  const queue = Array.isArray(items) ? items.slice() : []
+  if (!queue.length) {
+    return {
+      queue,
+      currentIndex: 0,
+      current: null,
+      next: null
+    }
+  }
+
+  queue.splice(currentIndex, 1)
+
+  if (!queue.length) {
+    return {
+      queue,
+      currentIndex: 0,
+      current: null,
+      next: null
+    }
+  }
+
+  const normalizedIndex = currentIndex >= queue.length ? 0 : currentIndex
+  return {
+    queue,
+    currentIndex: normalizedIndex,
+    current: queue[normalizedIndex],
+    next: queue[getWrappedNextIndex(normalizedIndex, queue.length)]
+  }
+}

--- a/frontend/src/utils/voteQueue.test.mjs
+++ b/frontend/src/utils/voteQueue.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getWrappedNextIndex, removeVotedFromQueue } from './voteQueue.js'
+
+test('wrapped next index loops to start', () => {
+  assert.equal(getWrappedNextIndex(0, 3), 1)
+  assert.equal(getWrappedNextIndex(1, 3), 2)
+  assert.equal(getWrappedNextIndex(2, 3), 0)
+  assert.equal(getWrappedNextIndex(0, 0), 0)
+})
+
+test('remove voted item advances to next remaining item', () => {
+  const items = [{ id: 'A' }, { id: 'B' }, { id: 'C' }]
+  const result = removeVotedFromQueue(items, 0)
+
+  assert.deepEqual(result.queue.map((i) => i.id), ['B', 'C'])
+  assert.equal(result.current.id, 'B')
+  assert.equal(result.next.id, 'C')
+  assert.equal(result.currentIndex, 0)
+})
+
+test('remove voted last item wraps current to first', () => {
+  const items = [{ id: 'A' }, { id: 'B' }, { id: 'C' }]
+  const result = removeVotedFromQueue(items, 2)
+
+  assert.deepEqual(result.queue.map((i) => i.id), ['A', 'B'])
+  assert.equal(result.current.id, 'A')
+  assert.equal(result.next.id, 'B')
+  assert.equal(result.currentIndex, 0)
+})
+
+test('single-item queue becomes empty after vote', () => {
+  const items = [{ id: 'A' }]
+  const result = removeVotedFromQueue(items, 0)
+
+  assert.deepEqual(result.queue, [])
+  assert.equal(result.current, null)
+  assert.equal(result.next, null)
+  assert.equal(result.currentIndex, 0)
+})


### PR DESCRIPTION
### Issue

The bug was in the voting UI, not in vote persistence. The frontend keeps a local batch of tasks in memory, then advances through that array with a wrapped index. If a voted item is left in the array, the UI can circle back to it and show it again before the next refresh replaces the batch. That is what made it look like a voted image was reappearing.

### Solution
I changed the vote flow so the just-voted item is removed from the local batch immediately, and the UI only advances within the remaining items. When the batch becomes empty, it fetches a fresh batch. The shared queue logic lives in `voteQueue.js`, with the vote views using it in `VoteRating.vue` and `VoteYesNo.vue`

I also added a focused regression test in `voteQueue.test.mjs`

### Test Results
|Before|After|
|----|----|
|<img width="699" height="360" alt="Screenshot 2026-04-12 at 3 28 40 PM" src="https://github.com/user-attachments/assets/23a3e9bb-4735-4245-a3e3-c70a099cd9fc" />|<img width="703" height="204" alt="Screenshot 2026-04-12 at 3 29 08 PM" src="https://github.com/user-attachments/assets/a71edbab-4940-44cd-878c-5e00af601bd3" />|

Closes #334 
