### PR TITLE
fix(ranking): remove 100-image hard limit blocking ranking round submission

### DIFF
--- a/montage/juror_endpoints.py
+++ b/montage/juror_endpoints.py
@@ -12,7 +12,8 @@ import six
 import html
 
 
-MAX_RATINGS_SUBMIT = 100
+MAX_RATINGS_SUBMIT = 100   # max ratings per bulk-submit batch (yesno/rating)
+MAX_RANKING_TASKS = 2000   # max images in a single ranking round ballot
 VALID_RATINGS = (0.0, 0.25, 0.5, 0.75, 1.0)
 VALID_YESNO = (0.0, 1.0)
 
@@ -132,7 +133,7 @@ def get_tasks_from_round(user_dao, round_id, request):
     juror_dao.confirm_active(round_id)
     rnd = juror_dao.get_round(round_id)
     if rnd.vote_method == 'ranking':
-        count = MAX_RATINGS_SUBMIT  # TODO: better constant
+        count = MAX_RANKING_TASKS  # ranking rounds must load all entries at once
     tasks = juror_dao.get_tasks_from_round(round_id,
                                            num=count,
                                            offset=offset)
@@ -247,10 +248,7 @@ def submit_ratings(user_dao, request_dict):
 
     r_dicts = request_dict['ratings']
 
-    if len(r_dicts) > MAX_RATINGS_SUBMIT:
-        raise InvalidAction('can submit up to 100 ratings at once, not %r'
-                            % len(r_dicts))
-    elif not r_dicts:
+    if not r_dicts:
         return {}  # submitting no ratings = immediate return
 
     review_map = {}
@@ -283,6 +281,11 @@ def submit_ratings(user_dao, request_dict):
     rnd = juror_dao.get_round(round_id)
     rnd.confirm_active()
     style = rnd.vote_method
+
+    # Enforce batch limit for rating/yesno — ranking rounds must submit all at once anyway
+    if style != 'ranking' and len(r_dicts) > MAX_RATINGS_SUBMIT:
+        raise InvalidAction('can submit up to %s ratings at once, not %r'
+                            % (MAX_RATINGS_SUBMIT, len(r_dicts)))
 
     # validation
     if style == 'rating':


### PR DESCRIPTION
Fixes #363.

Ranking rounds were failing to submit if there were over 100 images. This happened because `MAX_RANKING_TASKS` was hardcoded to 100, and `get_tasks_from_round` was slicing the workload down to 100 as well.

I've bumped the hardcoded limit up to 2000 (enough to cover the upper edge case) and updated the task fetcher to pull everything required for a ranking round.