### PR TITLE
fix(voting): Vote Later permanently hides images — replace skip watermark with ID list (#371 #372)

### DIFF
--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -2569,14 +2569,24 @@ class JurorDAO(object):
         )
         
         round_juror = self._get_round_juror(round_id)
-        
-        skip = None
+
+        skipped_ids = []
         if round_juror and round_juror.flags:
-            skip = round_juror.flags.get('skip')
-        
-        if skip:
-            return task_query.filter(Vote.id > skip).limit(num).all()
-        
+            raw = round_juror.flags.get('skipped_ids')
+            if isinstance(raw, list):
+                skipped_ids = raw
+            elif isinstance(raw, int):
+                # Migrate legacy single-watermark format to list (#371)
+                skipped_ids = [raw]
+
+        if skipped_ids:
+            # First: serve non-skipped tasks (exclude all explicitly skipped IDs)
+            non_skipped = task_query.filter(~Vote.id.in_(skipped_ids)).limit(num).all()
+            if non_skipped:
+                return non_skipped
+            # All non-skipped tasks done — now serve skipped ones so juror can finish (#371)
+            return task_query.filter(Vote.id.in_(skipped_ids)).limit(num).all()
+
         return task_query.limit(num).all()
 
     def get_faves(self, sort='desc', limit=10, offset=0):
@@ -2821,29 +2831,36 @@ class JurorDAO(object):
             .filter_by(id=vote_id, user=self.user)
             .one_or_none()
         )
-        
+
         if not vote:
             return InvalidAction('vote %s does not exist for this user' % vote_id)
-        
+
         if not round_id:
             round_id = vote.round_entry.round_id
-        
+
         round_juror = self._get_round_juror(round_id)
-        
+
         if not round_juror:
             return InvalidAction('round_juror not found')
-        
+
         if round_juror.flags is None:
             round_juror.flags = {}
-        
-        current_skip = round_juror.flags.get('skip')
-        if current_skip is None or vote_id > current_skip:
-            round_juror.flags['skip'] = vote_id
-            
+
+        # Migrate legacy single-watermark to list format (#371)
+        skipped_ids = round_juror.flags.get('skipped_ids')
+        if skipped_ids is None:
+            legacy = round_juror.flags.get('skip')
+            skipped_ids = [legacy] if legacy is not None else []
+
+        if vote_id not in skipped_ids:
+            skipped_ids.append(vote_id)
+            round_juror.flags['skipped_ids'] = skipped_ids
+            # Remove legacy key if present to avoid confusion
+            round_juror.flags.pop('skip', None)
+
             flag_modified(round_juror, 'flags')
-            
             self.rdb_session.add(round_juror)
-        
+
         return
 
     def apply_ranking(self, ballot):

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -2587,14 +2587,24 @@ class JurorDAO(object):
         )
         
         round_juror = self._get_round_juror(round_id)
-        
-        skip = None
+
+        skipped_ids = []
         if round_juror and round_juror.flags:
-            skip = round_juror.flags.get('skip')
-        
-        if skip:
-            return task_query.filter(Vote.id > skip).limit(num).all()
-        
+            raw = round_juror.flags.get('skipped_ids')
+            if isinstance(raw, list):
+                skipped_ids = raw
+            elif isinstance(raw, int):
+                # Migrate legacy single-watermark format to list (#371)
+                skipped_ids = [raw]
+
+        if skipped_ids:
+            # First: serve non-skipped tasks (exclude all explicitly skipped IDs)
+            non_skipped = task_query.filter(~Vote.id.in_(skipped_ids)).limit(num).all()
+            if non_skipped:
+                return non_skipped
+            # All non-skipped tasks done — now serve skipped ones so juror can finish (#371)
+            return task_query.filter(Vote.id.in_(skipped_ids)).limit(num).all()
+
         return task_query.limit(num).all()
 
     def get_faves(self, sort='desc', limit=10, offset=0):
@@ -2839,29 +2849,36 @@ class JurorDAO(object):
             .filter_by(id=vote_id, user=self.user)
             .one_or_none()
         )
-        
+
         if not vote:
             return InvalidAction('vote %s does not exist for this user' % vote_id)
-        
+
         if not round_id:
             round_id = vote.round_entry.round_id
-        
+
         round_juror = self._get_round_juror(round_id)
-        
+
         if not round_juror:
             return InvalidAction('round_juror not found')
-        
+
         if round_juror.flags is None:
             round_juror.flags = {}
-        
-        current_skip = round_juror.flags.get('skip')
-        if current_skip is None or vote_id > current_skip:
-            round_juror.flags['skip'] = vote_id
-            
+
+        # Migrate legacy single-watermark to list format (#371)
+        skipped_ids = round_juror.flags.get('skipped_ids')
+        if skipped_ids is None:
+            legacy = round_juror.flags.get('skip')
+            skipped_ids = [legacy] if legacy is not None else []
+
+        if vote_id not in skipped_ids:
+            skipped_ids.append(vote_id)
+            round_juror.flags['skipped_ids'] = skipped_ids
+            # Remove legacy key if present to avoid confusion
+            round_juror.flags.pop('skip', None)
+
             flag_modified(round_juror, 'flags')
-            
             self.rdb_session.add(round_juror)
-        
+
         return
 
     def apply_ranking(self, ballot):

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -954,3 +954,96 @@ def submit_ratings(client, round_id, coord_user='Yarl'):
     # get all the jurors that have open tasks in a round
     # get juror's tasks
     # submit random valid votes until there are no more tasks
+
+
+def test_vote_later_reappears(api_client, mock_external_apis):
+    """
+    Regression test for #371 / #372: skipped tasks ("Vote Later") should
+    reappear after the juror exhausts all remaining non-skipped tasks.
+
+    Without the fix: BUG #371 — get_tasks_from_round used a single-integer
+    watermark (Vote.id > skip), permanently hiding skipped images even after
+    all other tasks were completed.
+
+    With the fix: skips are stored as a list of vote IDs. Non-skipped tasks
+    are served first; only when none remain are the skipped ones returned.
+    """
+    fetch = api_client.fetch
+
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    resp = fetch('organizer: create campaign for vote-later test',
+                 '/admin/add_campaign',
+                 {'name': 'Vote Later Regression Test',
+                  'coordinators': [u'LilyOfTheWest', u'Slaporte', u'Yarl'],
+                  'open_date': '2015-09-01 17:00:00',
+                  'close_date': '2015-10-01 17:00:00',
+                  'url': 'http://hatnote.com',
+                  'series_id': series_id},
+                 as_user='Yarl')
+
+    resp = fetch('coordinator: get admin view', '/admin', as_user='LilyOfTheWest')
+    campaign_id = resp['data'][-1]['id']
+
+    resp = fetch('coordinator: add yesno round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 {'name': 'Vote Later Test Round',
+                  'vote_method': 'yesno',
+                  'quorum': 1,
+                  'deadline_date': '2025-10-20T00:00:00',
+                  'jurors': [u'Slaporte']},
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    fetch('coordinator: import entries',
+          '/admin/round/%s/import' % round_id,
+          {'import_method': 'category',
+           'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+          as_user='LilyOfTheWest')
+
+    fetch('coordinator: activate round',
+          '/admin/round/%s/activate' % round_id,
+          {'post': True}, as_user='LilyOfTheWest')
+
+    resp = fetch('juror: get initial tasks',
+                 '/juror/round/%s/tasks' % round_id,
+                 as_user='Slaporte')
+    all_tasks = resp['data']['tasks']
+    assert len(all_tasks) >= 2, 'need at least 2 tasks to test skip'
+
+    skip_vote_id = all_tasks[0]['id']
+    fetch('juror: skip first task',
+          '/juror/round/%s/tasks/skip' % round_id,
+          {'vote_id': skip_vote_id},
+          as_user='Slaporte')
+
+    # Skipped task must not appear immediately
+    resp = fetch('juror: get tasks right after skip',
+                 '/juror/round/%s/tasks' % round_id,
+                 as_user='Slaporte')
+    assert skip_vote_id not in [t['id'] for t in resp['data']['tasks']], (
+        'skipped task appeared immediately — should be deferred')
+
+    # Vote on all remaining non-skipped tasks until the skipped one reappears
+    found_skipped = False
+    for _ in range(200):
+        resp = fetch('juror: get remaining tasks',
+                     '/juror/round/%s/tasks' % round_id,
+                     as_user='Slaporte')
+        remaining = resp['data']['tasks']
+        if not remaining:
+            break
+        if any(t['id'] == skip_vote_id for t in remaining):
+            found_skipped = True
+            break
+        for task in remaining:
+            fetch('juror: vote on task',
+                  '/juror/round/%s/tasks/submit' % round_id,
+                  {'ratings': [{'vote_id': task['id'], 'value': 1}]},
+                  as_user='Slaporte')
+
+    assert found_skipped, (
+        'BUG #371: skipped task (vote_id=%s) never reappeared after all '
+        'non-skipped tasks were completed.' % skip_vote_id
+    )

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -1045,3 +1045,96 @@ def submit_ratings(client, round_id, coord_user='Yarl'):
     # get all the jurors that have open tasks in a round
     # get juror's tasks
     # submit random valid votes until there are no more tasks
+
+
+def test_vote_later_reappears(api_client, mock_external_apis):
+    """
+    Regression test for #371 / #372: skipped tasks ("Vote Later") should
+    reappear after the juror exhausts all remaining non-skipped tasks.
+
+    Without the fix: BUG #371 — get_tasks_from_round used a single-integer
+    watermark (Vote.id > skip), permanently hiding skipped images even after
+    all other tasks were completed.
+
+    With the fix: skips are stored as a list of vote IDs. Non-skipped tasks
+    are served first; only when none remain are the skipped ones returned.
+    """
+    fetch = api_client.fetch
+
+    resp = fetch('get default series', '/series')
+    series_id = resp['data'][0]['id']
+
+    resp = fetch('organizer: create campaign for vote-later test',
+                 '/admin/add_campaign',
+                 {'name': 'Vote Later Regression Test',
+                  'coordinators': [u'LilyOfTheWest', u'Slaporte', u'Yarl'],
+                  'open_date': '2015-09-01 17:00:00',
+                  'close_date': '2015-10-01 17:00:00',
+                  'url': 'http://hatnote.com',
+                  'series_id': series_id},
+                 as_user='Yarl')
+
+    resp = fetch('coordinator: get admin view', '/admin', as_user='LilyOfTheWest')
+    campaign_id = resp['data'][-1]['id']
+
+    resp = fetch('coordinator: add yesno round',
+                 '/admin/campaign/%s/add_round' % campaign_id,
+                 {'name': 'Vote Later Test Round',
+                  'vote_method': 'yesno',
+                  'quorum': 1,
+                  'deadline_date': '2025-10-20T00:00:00',
+                  'jurors': [u'Slaporte']},
+                 as_user='LilyOfTheWest')
+    round_id = resp['data']['id']
+
+    fetch('coordinator: import entries',
+          '/admin/round/%s/import' % round_id,
+          {'import_method': 'category',
+           'category': 'Images_from_Wiki_Loves_Monuments_2015_in_Albania'},
+          as_user='LilyOfTheWest')
+
+    fetch('coordinator: activate round',
+          '/admin/round/%s/activate' % round_id,
+          {'post': True}, as_user='LilyOfTheWest')
+
+    resp = fetch('juror: get initial tasks',
+                 '/juror/round/%s/tasks' % round_id,
+                 as_user='Slaporte')
+    all_tasks = resp['data']['tasks']
+    assert len(all_tasks) >= 2, 'need at least 2 tasks to test skip'
+
+    skip_vote_id = all_tasks[0]['id']
+    fetch('juror: skip first task',
+          '/juror/round/%s/tasks/skip' % round_id,
+          {'vote_id': skip_vote_id},
+          as_user='Slaporte')
+
+    # Skipped task must not appear immediately
+    resp = fetch('juror: get tasks right after skip',
+                 '/juror/round/%s/tasks' % round_id,
+                 as_user='Slaporte')
+    assert skip_vote_id not in [t['id'] for t in resp['data']['tasks']], (
+        'skipped task appeared immediately — should be deferred')
+
+    # Vote on all remaining non-skipped tasks until the skipped one reappears
+    found_skipped = False
+    for _ in range(200):
+        resp = fetch('juror: get remaining tasks',
+                     '/juror/round/%s/tasks' % round_id,
+                     as_user='Slaporte')
+        remaining = resp['data']['tasks']
+        if not remaining:
+            break
+        if any(t['id'] == skip_vote_id for t in remaining):
+            found_skipped = True
+            break
+        for task in remaining:
+            fetch('juror: vote on task',
+                  '/juror/round/%s/tasks/submit' % round_id,
+                  {'ratings': [{'vote_id': task['id'], 'value': 1}]},
+                  as_user='Slaporte')
+
+    assert found_skipped, (
+        'BUG #371: skipped task (vote_id=%s) never reappeared after all '
+        'non-skipped tasks were completed.' % skip_vote_id
+    )


### PR DESCRIPTION
Fixes #371 and #372.

The "Vote Later" skip logic was dropping tasks completely because it relied on a single integer watermark (`skip`) in `round_juror.flags`. Once a task's ID became less than that skip threshold, the `get_tasks_from_round` query excluded it permanently.

I've refactored `skip_voting` to maintain a basic list of `skipped_ids` instead. Now, skipped tasks are excluded temporarily and reappear once the rest of the queue is finished. 

Added testing for this in `test_web_basic.py`.