### PR TITLE
fix(ui): enforce threshold selection for ranking rounds to prevent 500 error (#383)

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -325,6 +325,14 @@ const submitRound = () => {
     return
   }
 
+  // Validate that a threshold is selected for ranking rounds (#383)
+  if (formData.value.vote_method === 'ranking' && !formData.value.threshold && formData.value.threshold !== 0) {
+    alertService.error({
+      message: $t('montage-required-fill-inputs') // Standard form validation error
+    })
+    return
+  }
+
   // Check if the round is the first round
   if (roundIndex === 0) {
     const payload = {


### PR DESCRIPTION
Fixes #383.

If a ranking round was submitted without a threshold, `threshold: null` was being sent to the API. Since the backend expects an int/float, this silently crashed the request with a 500 error.

I added a quick check in `RoundNew.vue` to trap this locally and trigger the standard form validation alert (`alertService.error`) instead, avoiding the network crash entirely.