### PR TITLE
build: drop obsolete pluggy<1 dev pin

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 
-tox<3.15.0  # tox 3.x requires pluggy<1; upgrade to tox 4.x to drop both pins
-pluggy<1
+tox<3.15.0
 Fabric3
 coverage==5.0.2
 pytest>=7,<9

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ certifi==2024.2.2
     # via
     #   requests
     #   sentry-sdk
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
@@ -106,6 +106,11 @@ sqlalchemy==1.2.19
     # via
     #   -r requirements.in
     #   sqltap
+setuptools==81.0.0
+    # via python-graph-core (pkg_resources namespace; implicit dep on Python 3.13)
+    # Pinned <82: setuptools 82 removed pkg_resources entirely; python-graph-core
+    # depends on it via namespace packages. Remove this pin once python-graph-core
+    # no longer uses pkg_resources (tracked in hatnote/montage#421).
 sqlparse==0.5.0
     # via sqltap
 sqltap==0.3.11


### PR DESCRIPTION
The `cffi 1.17.1` and `setuptools<82` pins this PR originally introduced have already landed in master via #505. The only remaining change is dropping the now-obsolete `pluggy<1` dev pin from `requirements-dev.txt`.

Note: #573 supersedes this by upgrading to tox 4.x (which drops the pin properly) — this PR can be closed in favor of #573 if preferred.