### PR TITLE
fix(backend): remove stale pdb breakpoints and bare except clause

### DIFF
--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -543,8 +543,7 @@ def get_round_results_preview(user_dao, round_id):
         data['ratings'] = coord_dao.get_round_average_rating_map(round_id)
         try:
             data['thresholds'] = get_threshold_map(data['ratings'])
-        except:
-            # import pdb;pdb.post_mortem()
+        except Exception:
             raise
     elif rnd.vote_method == 'ranking':
         completed_votes_count = round_counts.get('total_tasks', 0) - round_counts.get('total_open_tasks', 0)
@@ -552,7 +551,7 @@ def get_round_results_preview(user_dao, round_id):
             # TODO: What should this return for ranking rounds? The ranking
             # round is sorta an all-or-nothing deal, unlike the rating rounds
             # where you can take a peek at in-progress results
-            # import pdb;pdb.set_trace()
+            # ranking round: all-or-nothing, can't peek at partial results
             return {'status': 'failure',
                     '_status_code': 400,
                     'errors': ('cannot preview results of a ranking '

--- a/montage/labs.py
+++ b/montage/labs.py
@@ -112,4 +112,4 @@ def get_file_info(filename):
 
 if __name__ == '__main__':
     imgs = get_files('Images_from_Wiki_Loves_Monuments_2015_in_France')
-    import pdb; pdb.set_trace()
+    print('%d file(s) returned' % len(imgs))

--- a/montage/utils.py
+++ b/montage/utils.py
@@ -182,7 +182,6 @@ def check_schema(db_url, base_type, echo=False, autoexit=False):
     session_type = sessionmaker()
     session_type.configure(bind=engine)
 
-    # import pdb;pdb.set_trace()
 
     tmp_rdb_session = session_type()
     schema_errors = get_schema_errors(base_type, tmp_rdb_session)


### PR DESCRIPTION
Closes #523

Removes leftover debugging artifacts across three backend modules:

| File | Line | Change |
|------|------|--------|
| `labs.py` | 115 | **Active** `pdb.set_trace()` replaced with `print()` |
| `admin_endpoints.py` | 546 | Bare `except:` narrowed to `except Exception:` (PEP 8 E722) |
| `admin_endpoints.py` | 547, 555 | Commented-out `pdb` imports removed |
| `utils.py` | 185 | Commented-out `pdb` import removed |

All existing tests pass. Zero functional change outside the `__main__` guard in `labs.py`.