### PR TITLE
fix: guard against empty entry list in download_round_entries_csv

### DIFF
--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -109,6 +109,8 @@ def download_round_entries_csv(user_dao, round_id):
     rnd = coord_dao.get_round(round_id)
     entries = coord_dao.get_round_entries(round_id)
     entry_infos = [e.to_export_dict() for e in entries]
+    if not entry_infos:
+        raise InvalidAction('no entries in round, cannot export CSV')
     output_name = 'montage_entries-%s.csv' % slugify(rnd.name, ascii=True).decode('ascii')
     output = io.BytesIO()
     csv_fieldnames = sorted(entry_infos[0].keys())


### PR DESCRIPTION
Fixes #531.

`download_round_entries_csv` assumed at least one entry existed and read `entry_infos[0]` to derive CSV field names. When a round has no entries (never imported, or all entries DQ'd), this raises `IndexError` and returns a 500.

The fix adds an explicit guard before that line and raises `InvalidAction`, which Clastic maps to a clean 400 response.

```python
 entry_infos = [e.to_export_dict() for e in entries]
+if not entry_infos:
+    raise InvalidAction('no entries in round, cannot export CSV')
 output_name = 'montage_entries-%s.csv' % ...
```

## Reproduction

Start a local devtest server, then:

```bash
BASE=http://localhost:5555/v1
COOKIE='clastic_cookie=W7XGXxmUjl4kbkE0TWaFo4Oth50=?userid=NjAyNDQ3NA==&username=IlNsYXBvcnRlIg=='

SID=$(curl -s -b "$COOKIE" -X POST $BASE/admin/add_series \
  -H 'Content-Type: application/json' \
  -d '{"name":"S","description":"x","url":"http://example.com"}' \
  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['id'])")

CID=$(curl -s -b "$COOKIE" -X POST $BASE/admin/add_campaign \
  -H 'Content-Type: application/json' \
  -d "{\"name\":\"531 test\",\"coordinators\":[\"Slaporte\"],\"close_date\":\"2010-01-02 17:00:00\",\"open_date\":\"2010-01-01 17:00:00\",\"url\":\"http://example.com\",\"series_id\":$SID}" \
  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['id'])")

RID=$(curl -s -b "$COOKIE" -X POST $BASE/admin/campaign/$CID/add_round \
  -H 'Content-Type: application/json' \
  -d '{"name":"Empty Round","vote_method":"yesno","quorum":1,"deadline_date":"2026-10-15T00:00:00","jurors":["Slaporte"]}' \
  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['id'])")

curl -b "$COOKIE" $BASE/admin/round/$RID/entries/download
```

## Before / after

copy of the error messages attached in a comment below.