### PR TITLE
fix(backend): return 400 instead of 500 when threshold is null in advance_round

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -361,6 +361,12 @@ const submitRound = () => {
       alertService.error($t('montage-something-went-wrong'))
       return
     }
+    if (thresholds.value && !formData.value.threshold) {
+      alertService.error({
+        message: $t('montage-required-threshold')
+      })
+      return
+    }
 
     const payload = {
       next_round: {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -138,6 +138,7 @@
   "montage-vote-accept": "Accept",
   "montage-vote-decline": "Decline",
   "montage-vote-keyboard-instructions": "You can also use the keyboard to vote.",
+  "montage-required-threshold": "Please select a threshold before continuing.",
   "montage-vote-actions": "Actions",
   "montage-vote-add-favorites": "Add to favorites",
   "montage-vote-added-favorites": "Image added to favorites",

--- a/frontend/src/i18n/qqq.json
+++ b/frontend/src/i18n/qqq.json
@@ -131,6 +131,7 @@
 	"montage-round-vote-method": "Label for the vote method setting in a round.",
 	"montage-round-threshold-description": "Description for the threshold setting, explaining its purpose.",
 	"montage-round-threshold-default": "Placeholder text for the threshold setting.",
+	"montage-required-threshold": "Validation error shown when a coordinator tries to advance a round without selecting a threshold value.",
 	"montage-round-jurors-description": "Description for the jurors input field, explaining its purpose.",
 	"montage-round-quorum-description": "Description for the quorum input field, explaining its purpose.",
 	"montage-no-results": "Message displayed when no results are found.",

--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -590,7 +590,7 @@ def advance_round(user_dao, round_id, request_dict):
         raise NotImplementedResponse()  # see docstring above
     try:
         threshold = float(request_dict['threshold'])
-    except KeyError:
+    except (KeyError, TypeError, ValueError):
         raise InvalidAction('unset threshold. set the threshold and try again.')
     _next_round_params = request_dict['next_round']
     nrp = _prepare_round_params(coord_dao, _next_round_params)


### PR DESCRIPTION
Closes #383.

## What changed

**Frontend** (cherry-picked from #384, authored by @Oyelakin-Mercy): validates that a threshold is selected before submitting the advance-round form, showing a specific error message (`montage-required-threshold`) rather than letting the request through.

**Backend** (`admin_endpoints.py`): the existing `except KeyError` did not catch the case where `threshold` is present in the request but set to `null` — `float(None)` raises `TypeError`, not `KeyError`, so the exception propagated as an unhandled 500. Fix catches `TypeError` and `ValueError` alongside `KeyError`.

**i18n**: adds the missing `qqq.json` documentation entry for `montage-required-threshold`.

## Reproduction

```bash
python .claude/reproduce_383.py   # requires local instance with debug: true
```

Before: `threshold: null` → 500 Internal Server Error  
After: `threshold: null` → 400 with `"unset threshold. set the threshold and try again."`