### PR TITLE
fix: remove active pdb breakpoints and bare except clause

### DIFF
--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -543,7 +543,7 @@ def get_round_results_preview(user_dao, round_id):
         data['ratings'] = coord_dao.get_round_average_rating_map(round_id)
         try:
             data['thresholds'] = get_threshold_map(data['ratings'])
-        except:
+        except Exception:
             # import pdb;pdb.post_mortem()
             raise
     elif rnd.vote_method == 'ranking':

--- a/montage/labs.py
+++ b/montage/labs.py
@@ -112,4 +112,4 @@ def get_file_info(filename):
 
 if __name__ == '__main__':
     imgs = get_files('Images_from_Wiki_Loves_Monuments_2015_in_France')
-    import pdb; pdb.set_trace()
+    print('got %d images' % len(imgs))

--- a/montage/mw/__init__.py
+++ b/montage/mw/__init__.py
@@ -65,7 +65,6 @@ class MessageMiddleware(Middleware):
         except Exception as e:
             if self.debug_errors and not isinstance(e, MontageError):
                 import pdb; pdb.post_mortem()
-                import pdb;pdb.set_trace()
             if self.raise_errors:
                 raise
             ret = None


### PR DESCRIPTION
Closes #523.

**Changes:**

- `montage/mw/__init__.py`: Removed the live `pdb.set_trace()` call on line 68, which was placed immediately after `pdb.post_mortem()`. If `debug_errors=True`, this would freeze the process interactively -- `post_mortem()` alone is the right tool here.
- `montage/labs.py`: Removed `pdb.set_trace()` from the `__main__` block. Replaced with a simple `print()` so the script remains usable for quick manual testing without freezing.
- `montage/admin_endpoints.py`: Replaced bare `except:` with `except Exception:` in `get_round_results_preview`. The bare form catches `SystemExit` and `KeyboardInterrupt` which should never be swallowed silently.