### PR TITLE
fix: resolve fave/unfave cross-campaign collision and NoResultFound error

### DIFF
--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -2871,30 +2871,42 @@ class JurorDAO(object):
         return
 
     def fave(self, round_id, entry_id):
+        round_entry = self.get_round_entry(round_id, entry_id)
+        campaign_id = round_entry.round.campaign.id
+
+        # scope the lookup to this campaign to avoid cross-campaign collision
+        # (same image can appear in multiple campaigns -- see issue #526)
         existing_fave = (self.query(Favorite)
                              .filter_by(entry_id=entry_id,
+                                        campaign_id=campaign_id,
                                         user=self.user)
-                             .first())  # there should be one
+                             .first())
         if existing_fave:
             existing_fave.modified_date = datetime.datetime.utcnow()
             existing_fave.status = ACTIVE_STATUS
             return
 
-        round_entry = self.get_round_entry(round_id, entry_id)
         fave = Favorite(entry_id=round_entry.entry.id,
-                       round_entry_id = round_entry.id,
-                       campaign_id=round_entry.round.campaign.id,
+                       round_entry_id=round_entry.id,
+                       campaign_id=campaign_id,
                        user=self.user,
                        status=ACTIVE_STATUS)
         self.rdb_session.add(fave)
 
     def unfave(self, round_id, entry_id):
+        round_entry = self.get_round_entry(round_id, entry_id)
+        campaign_id = round_entry.round.campaign.id
+
+        # scope to this campaign + round to avoid cross-campaign match (#526/#527)
         fave = (self.query(Favorite)
                .join(RoundEntry, RoundEntry.id == Favorite.round_entry_id)
                .filter(Favorite.entry_id == entry_id,
+                       Favorite.campaign_id == campaign_id,
                        Favorite.user == self.user,
                        RoundEntry.round_id == round_id)
-               .one())
+               .one_or_none())
+        if fave is None:
+            return  # already unfaved or never faved, nothing to do
         fave.status = CANCELLED_STATUS
         fave.modified_date = datetime.datetime.utcnow()
 


### PR DESCRIPTION
Fixes #526, fixes #527.

**Root cause**: `fave()` queried `Favorite` only by `entry_id + user`, ignoring `campaign_id`. If the same image appeared in two campaigns, it would find the fave from the *other* campaign and activate it -- creating a cross-campaign state collision.

**Fix**: Scope the existence check to `campaign_id` in `fave()`. The `round_entry` lookup already happens anyway (for creating the new fave), so fetching `campaign_id` from it adds no extra query.

**Also fixed**: `unfave()` used `.one()` which raises `NoResultFound` if the fave was never created (e.g. due to a prior collision or partial state). Changed to `.one_or_none()` with an explicit guard -- unfaving something that is not faved is a no-op, not a 500 error.