### PR TITLE
fix: null-check rnd.name before slugify in download_results_csv

### DIFF
--- a/montage/admin_endpoints.py
+++ b/montage/admin_endpoints.py
@@ -761,8 +761,11 @@ def get_results(user_dao, round_id, request_dict):
 def download_results_csv(user_dao, round_id, request_dict):
     coord_dao = CoordinatorDAO.from_round(user_dao, round_id)
     rnd = coord_dao.get_round(round_id)
-    now = datetime.datetime.now().isoformat()
-    output_name = 'montage_results-%s-%s.csv' % (slugify(rnd.name, ascii=True).decode('ascii'), now)
+    now = datetime.datetime.now().isoformat().replace(':', '-')
+    # guard for None name -- slugify() blows up with AttributeError otherwise
+    round_name = rnd.name or 'unnamed-round'
+    output_name = 'montage_results-%s-%s.csv' % (slugify(round_name, ascii=True).decode('ascii'), now)
+
 
     # TODO: Confirm round is finalized
     # raise DoesNotExist('round results not yet finalized')


### PR DESCRIPTION
Fixes #542.

`slugify(rnd.name, ...)` raises `AttributeError` if `rnd.name` is `None`. Added a null-guard with a sensible fallback (`unnamed-round`).

Also replaced colons in `isoformat()` output with dashes since colons in filenames cause issues on Windows/macOS when downloading the CSV.