### PR TITLE
fix: load_partial_csv fallback in Google Sheet imports wraps response in DictReader

### DIFF
--- a/montage/loaders.py
+++ b/montage/loaders.py
@@ -182,7 +182,10 @@ def get_entries_from_gsheet(raw_url, source='local'):
         ret, warnings = load_full_csv(BytesIO(resp.content), source=source)
     except ValueError:
         try:
-            ret, warnings = load_partial_csv(resp)  # TODO: load_partial_csv expects a dictreader, did this ever work?
+            # load_partial_csv expects a DictReader, not a raw Response -- wrap it properly
+            from unicodecsv import DictReader as UDictReader
+            dr = UDictReader(BytesIO(resp.content))
+            ret, warnings = load_partial_csv(dr, source=source)
         except (ValueError, TypeError):
             resp_content = resp.content.decode('utf8')
             file_names = [fn.strip('\"') for fn in resp_content.split('\n')]


### PR DESCRIPTION
Fixes #517.

The fallback path in `get_entries_from_gsheet` called `load_partial_csv(resp)` passing the raw `requests.Response` object directly. The function expects a `DictReader` (it immediately does `[r["filename"] for r in dr]`), so this **always** raised a `TypeError` and permanently fell through to the last-resort filename-splitting path.

The TODO comment in the code even acknowledged this: `# TODO: load_partial_csv expects a dictreader, did this ever work?`

**Fix**: Wrap `resp.content` in `BytesIO` and pass it through `unicodecsv.DictReader` before calling `load_partial_csv`. The existing `except (ValueError, TypeError)` fallback is preserved for any subsequent failures.