### PR TITLE
fix: robust API error handling for invalid thresholds & ranking stats

### DIFF
--- a/montage/juror_endpoints.py
+++ b/montage/juror_endpoints.py
@@ -182,10 +182,12 @@ def get_votes_stats_from_round(user_dao, round_id):
         # dict: raw value => number of stars
         vote_map = {0.0: 1, 0.25: 2, 0.5: 3, 0.75: 4, 1.0: 5}
         stats = _get_summarized_votes_stats(juror_dao, round_id, vote_map)
+    elif rnd.vote_method == 'ranking':
+        stats = {}
+    else:
+        stats = {}
 
-    result = None
-    if stats is not None:
-        result = {'method': rnd.vote_method, 'stats': stats}
+    result = {'method': rnd.vote_method, 'stats': stats}
 
     return result
 

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -1862,7 +1862,8 @@ class CoordinatorDAO(UserDAO):
         if threshold is None:
             raise ValueError('expected threshold or finalized round')
 
-        assert 0.0 <= threshold <= 1.0
+        if not (0.0 <= threshold <= 1.0):
+            raise InvalidAction('threshold must be between 0.0 and 1.0, not %r' % threshold)
 
         avg = func.avg(Vote.value).label('average')
 


### PR DESCRIPTION
This PR hardens API failure boundaries by addressing two separate issues:

1. `montage/rdb.py`: Replaced `assert 0.0 <= threshold <= 1.0` with an explicit `InvalidAction`. When advanced boundaries were breached, raw assertions threw 500 internal server errors. Now it cleanly issues a 400 Bad Request.

2. `montage/juror_endpoints.py`: Modified `get_votes_stats_from_round()` to guarantee consistent structured responses. It previously returned `None` for ranking layouts or unrecognized vote methods, which violated client contracts.