### PR TITLE
feat: implement entry ID lookup by filename for jurors

### DIFF
--- a/montage/juror_endpoints.py
+++ b/montage/juror_endpoints.py
@@ -50,7 +50,8 @@ def get_juror_routes():
            POST('/juror/round/<round_id:int>/<entry_id:int>/unfave',
                 remove_fave),
            POST('/juror/round/<round_id:int>/<entry_id:int>/flag', submit_flag),
-           GET('/juror/faves', get_faves)]
+           GET('/juror/faves', get_faves),
+           GET('/juror/entry_lookup', get_entry_lookup)]
     ui = []
     return api, ui
 
@@ -233,6 +234,26 @@ def get_faves(user_dao, request_dict):
     return {'data': [f.to_details_dict() for f in faves]}
 
 
+def get_entry_lookup(user_dao, request):
+    filename = request.values.get('filename')
+    if not filename:
+        return {'data': None,
+                'status': 'failure',
+                'errors': 'filename required'}
+    
+    # standardize filename
+    if filename.lower().startswith('file:'):
+        filename = filename[5:]
+    filename = filename.strip().replace(' ', '_')
+    if not filename:
+        return {'data': None,
+                'status': 'failure',
+                'errors': 'invalid filename'}
+
+    entry = user_dao.get_entry_by_name(filename)
+    return {'data': entry.to_details_dict(with_uploader=True)}
+
+
 def submit_ratings(user_dao, request_dict):
     """message format:
 
@@ -376,5 +397,4 @@ JUROR_API_ROUTES, JUROR_UI_ROUTES = get_juror_routes()
 
 # TODO: Cave -> key-value store
 # TODO: flag RoundEntries (only applicable on ratings rounds?)
-# TODO: entry ID lookup by filename (should also return uploader, etc.)
 # TODO: manual disqualificatin for coordinators

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -1036,6 +1036,14 @@ class UserDAO(PublicDAO):
             raise Forbidden('not a coordinator for round %s' % round_id)
         return rnd
 
+    def get_entry_by_name(self, name):
+        entry = (self.query(Entry)
+                     .filter_by(name=name)
+                     .one_or_none())
+        if not entry:
+            raise DoesNotExist('entry %s does not exist' % name)
+        return entry
+
     def get_or_create_user(self, user, role, **kw):
         # kw is for including round/round_id/campaign/campaign_id
         # which is used in the audit log if the user is created


### PR DESCRIPTION
This PR clears a long-standing TODO in `juror_endpoints.py` by implementing a filename-based entry lookup for jurors.

### Changes:
- Added `get_entry_by_name` to `UserDAO` in `rdb.py` to support global entry lookups.
- Implemented `GET /juror/entry_lookup` endpoint which accepts a `filename` parameter.
- Added filename standardisation (removing `File:` prefix, handling spaces/underscores) to ensure robust lookups.
- The endpoint returns full entry details including uploader information, width, height, and MediaWiki URLs.

This is a highly useful utility for jurors who need to cross-reference specific files by name rather than internal database IDs.