### PR TITLE
fix: add database-level UniqueConstraint to Favorite model

### DIFF
--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -23,7 +23,8 @@ from sqlalchemy import (Text,
                         DateTime,
                         TIMESTAMP,
                         ForeignKey,
-                        inspect)
+                        inspect,
+                        UniqueConstraint)
 from sqlalchemy.sql import func, asc
 from sqlalchemy.orm import relationship, joinedload
 from sqlalchemy.sql.expression import select
@@ -685,6 +686,7 @@ class Flag(Base):
 
 class Favorite(Base):
     __tablename__ = 'favorites'
+    __table_args__ = (UniqueConstraint('user_id', 'entry_id', 'campaign_id'),)
 
     id = Column(Integer, primary_key=True)
     entry_id = Column(Integer, ForeignKey('entries.id'), index=True)


### PR DESCRIPTION
This PR adds a `UniqueConstraint` to the `Favorite` model across the `user_id`, `entry_id`, and `campaign_id` columns.

### Why:
In a previous fix (#540), we discovered that favorites were leaking across campaigns because they were only scoped to `user` + `entry`. This database-level constraint ensures data integrity at the schema level, preventing duplicate favorites from ever being created.

### Impact:
- Prevents duplicate `Favorite` rows in the database.
- Explicitly documents the intended identity of a Favorite record.
- Future-proofs the model for cleaner migrations.

This resolves the underlying database task mentioned in Issue #541.