### PR TITLE
fix: juror round listing shows wrong rounds

### DIFF
--- a/frontend/src/components/Round/RoundEdit.vue
+++ b/frontend/src/components/Round/RoundEdit.vue
@@ -100,9 +100,6 @@ import Delete from 'vue-material-design-icons/Delete.vue'
 import alertService from '@/services/alertService'
 import adminService from '@/services/adminService'
 import dialogService from '@/services/dialogService'
-import { useRouter } from 'vue-router'
-
-const router = useRouter()
 const { t: $t } = useI18n()
 const props = defineProps({
   round: Object,

--- a/montage/juror_endpoints.py
+++ b/montage/juror_endpoints.py
@@ -83,7 +83,7 @@ def get_index(user_dao, only_active=True):
     Summary: Get juror-level index of active campaigns and rounds.
     """
     juror_dao = JurorDAO(user_dao)
-    counts = juror_dao.get_all_rounds_task_counts(only_active=True)
+    counts = juror_dao.get_all_rounds_task_counts(only_active=only_active)
     stats = [make_juror_round_details(rnd, rnd_stats, ballot)
              for rnd, rnd_stats, ballot in counts]
     return stats

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -2707,6 +2707,9 @@ class JurorDAO(object):
         if only_active:
             users_rounds_query = users_rounds_query.where(campaigns_t.c.status == 'active')
             users_rounds_query = users_rounds_query.where(campaigns_t.c.is_archived == False)
+            users_rounds_query = users_rounds_query.where(
+                rounds_t.c.status.in_([ACTIVE_STATUS, PAUSED_STATUS])
+            )
 
         users_rounds_query = users_rounds_query.group_by(
             rounds_t.c.id,

--- a/montage/rdb.py
+++ b/montage/rdb.py
@@ -2708,7 +2708,7 @@ class JurorDAO(object):
             users_rounds_query = users_rounds_query.where(campaigns_t.c.status == 'active')
             users_rounds_query = users_rounds_query.where(campaigns_t.c.is_archived == False)
             users_rounds_query = users_rounds_query.where(
-                rounds_t.c.status.in_([ACTIVE_STATUS, PAUSED_STATUS])
+                rounds_t.c.status == ACTIVE_STATUS
             )
 
         users_rounds_query = users_rounds_query.group_by(

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -750,7 +750,7 @@ def test_home_client(base_client, api_client, mock_external_apis):
 
     resp = fetch('juror: check archived campaign rounds shown',
                  '/juror', as_user='Slaporte')
-    assert len(resp['data']) == 1  # only active/paused rounds shown; rounds 1+2 are finalized
+    assert len(resp['data']) == 1  # only active rounds shown; rounds 1+2 are finalized
     assert glom(resp, 'data.0.campaign.is_archived') is False
 
 

--- a/montage/tests/test_web_basic.py
+++ b/montage/tests/test_web_basic.py
@@ -750,7 +750,7 @@ def test_home_client(base_client, api_client, mock_external_apis):
 
     resp = fetch('juror: check archived campaign rounds shown',
                  '/juror', as_user='Slaporte')
-    assert len(resp['data']) > 1  # 4 rounds at time of writing
+    assert len(resp['data']) == 1  # only active/paused rounds shown; rounds 1+2 are finalized
     assert glom(resp, 'data.0.campaign.is_archived') is False
 
 


### PR DESCRIPTION
## Summary

- Fixes juror round listing to filter by round status, not just campaign status — finalized and cancelled rounds inside active campaigns were showing up and producing a confusing 400 \"round not active\" error when clicked
- Restricts the active view to rounds with `status IN (active, paused)` in the first pass, then narrows to `active` only (open question: should paused rounds be visible to jurors in read-only mode? see discussion)
- Fixes `get_index()` passthrough bug where `only_active=False` was ignored when calling `get_all_rounds_task_counts`, causing `/juror/campaigns/all` to always return an empty list
- Removes unused `router` import in `RoundEdit.vue`

Root cause: `e3069dd` (#350) added `finalize_round` which can finalize individual rounds without advancing the campaign, creating a state the juror listing never filtered for.

## Open question

Should paused rounds appear in the juror active view (read-only / greyed out) or be hidden entirely? Currently hidden (`== ACTIVE_STATUS`). Showing them (`IN (active, paused)`) matches how `Campaign.active_round` treats pause state, but jurors clicking a paused round get a 400 — that would need a frontend affordance or a dedicated endpoint.

## Test plan

- [ ] Juror index does not show finalized or cancelled rounds from active campaigns
- [ ] Juror index does not show paused rounds (current behaviour — revisit after discussion above)
- [ ] `/juror/campaigns/all` returns finalized rounds correctly
- [ ] `pytest montage/tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)