### PR TITLE
fix(frontend): validate threshold selection before advancing round (#383)

### DIFF
--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -362,6 +362,13 @@ const submitRound = () => {
       return
     }
 
+    if (thresholds.value && !formData.value.threshold) {
+      alertService.error({
+        message: $t('montage-required-threshold')
+      })
+      return
+    }
+
     const payload = {
       next_round: {
         name: formData.value.name,

--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -362,7 +362,12 @@ const submitRound = () => {
       return
     }
 
-    if (thresholds.value && !formData.value.threshold) {
+    // Check for "nothing selected" explicitly rather than falsiness: 0.0 is a
+    // valid threshold (advance all), so `!threshold` would wrongly block it.
+    if (
+      thresholds.value &&
+      (formData.value.threshold == null || formData.value.threshold === '')
+    ) {
       alertService.error({
         message: $t('montage-required-threshold')
       })

--- a/frontend/src/components/Round/RoundNew.vue
+++ b/frontend/src/components/Round/RoundNew.vue
@@ -364,10 +364,7 @@ const submitRound = () => {
 
     // Check for "nothing selected" explicitly rather than falsiness: 0.0 is a
     // valid threshold (advance all), so `!threshold` would wrongly block it.
-    if (
-      thresholds.value &&
-      (formData.value.threshold == null || formData.value.threshold === '')
-    ) {
+    if (thresholds.value && (formData.value.threshold == null || formData.value.threshold === '')) {
       alertService.error({
         message: $t('montage-required-threshold')
       })

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -187,6 +187,7 @@
   "permission-denied-home": "Go to Home",
   "montage-required-voting-deadline": "Choose a valid voting deadline",
   "montage-required-fill-inputs": "Please fill all the boxes",
+  "montage-required-threshold": "Please select a threshold before continuing",
   "unsaved-changes-confirmation": "There are unsaved changes. Are you sure you want to leave?",
   "back-to-round": "Back to round"
 }

--- a/frontend/src/i18n/qqq.json
+++ b/frontend/src/i18n/qqq.json
@@ -127,6 +127,7 @@
 	"montage-round-no-category": "Message displayed when no categories are found.",
 	"montage-round-file-url": "Label for the file URL input field.",
 	"montage-round-file-list": "Label for the file list input field.",
+	"montage-required-threshold": "Error shown when the user tries to advance a round without selecting a threshold percentage.",
 	"montage-round-threshold": "Label for the threshold setting in a round.",
 	"montage-round-vote-method": "Label for the vote method setting in a round.",
 	"montage-round-threshold-description": "Description for the threshold setting, explaining its purpose.",


### PR DESCRIPTION
## What & why

Fixes the frontend half of hatnote/montage#383: when a coordinator advances into a new round, the form shows a threshold dropdown. Submitting **without picking a threshold** sent an empty value to the backend, which surfaced as a raw network/500 error instead of clear feedback.

This adds a **pre-flight guard** in `submitRound()` so the bad request is never sent — the coordinator gets an i18n error and stays on the form.

## Changes

- `RoundNew.vue` — guard in `submitRound()`: if the threshold dropdown is shown but nothing is selected, show `montage-required-threshold` and abort submission.
- `en.json` / `qqq.json` — new i18n key + translator note.
- The guard checks for "nothing selected" explicitly (`== null || === ''`) rather than falsiness, because **`0.0` ("advance all") is a valid threshold** that the backend's `get_threshold_map` offers — a `!threshold` check would wrongly block it.

## Relationship to other work

- Complements backend PR hatnote/montage#533 (return 400 instead of 500 when threshold is null). Together they fully close #383: this prevents the bad request client-side, #533 hardens the server if one slips through.
- Based on earlier work by Oyelakin Mercy in hatnote/montage#384.

## Testing

- `npm run lint` clean.
- Manual: advance a round with the threshold dropdown visible and nothing selected → inline error, no request sent. Selecting any threshold (including the `0.0` option) → submits normally.

Opening as **draft** for review.
