### PR TITLE
fix(frontend): remove unused router import in RoundEdit.vue

### DIFF
--- a/frontend/src/components/Round/RoundEdit.vue
+++ b/frontend/src/components/Round/RoundEdit.vue
@@ -100,9 +100,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
 import alertService from '@/services/alertService'
 import adminService from '@/services/adminService'
 import dialogService from '@/services/dialogService'
-import { useRouter } from 'vue-router'
 
-const router = useRouter()
 const { t: $t } = useI18n()
 const props = defineProps({
   round: Object,


### PR DESCRIPTION
Dead code left by #380 (`b613b20`): `useRouter`/`router` in `RoundEdit.vue` became unused once `router.reload` was replaced with a data reload, but the import stayed. It trips `no-unused-vars`, which fails frontend lint on **every** branch (pre-existing on master).

Removes the two orphaned lines. `eslint src/components/Round/RoundEdit.vue` now clean.

Opening as draft.