### PR TITLE
fix: Added existing openImage functionality via vote-gallary-expand-icon missing in Yes/No mode 

### DIFF
--- a/frontend/src/components/Vote/VoteEdit.vue
+++ b/frontend/src/components/Vote/VoteEdit.vue
@@ -100,6 +100,9 @@
         <div class="gallery-image-fav" v-if="image.is_fave">
           <heart />
         </div>
+        <div class="vote-gallery-expand-icon" @click="openImage(image)">
+          <arrow-expand-all />
+        </div>
         <div class="gallery-image-container">
           <CommonsImage :image="image" :width="640" />
         </div>


### PR DESCRIPTION
Fixes:  https://github.com/hatnote/montage/issues/321

Fix :
Added existing openImage functionality via vote-gallary-expand-icon missing in Yes/No mode.

Before Fix: There is no expand icon for each image when i edit votes in Ye/No type Round
<img width="1847" height="967" alt="Screenshot from 2026-06-26 12-43-47" src="https://github.com/user-attachments/assets/2370e693-548f-4789-af0e-7e5173945781" />


After Fix: Just added the expand icon which is similar to other rounds (Ranking)
  
<img width="1847" height="967" alt="Screenshot from 2026-06-26 12-44-36" src="https://github.com/user-attachments/assets/5ae2e22e-d2d0-449e-b98a-87a9ed10fb71" />

<img width="1847" height="967" alt="WithFix" src="https://github.com/user-attachments/assets/631db5da-0ec0-4f97-92d6-e217c172b193" />
 