### PR TITLE
Disabled Edit Round button when round is active and added entries in i18n

### DIFF
--- a/frontend/src/components/Round/RoundView.vue
+++ b/frontend/src/components/Round/RoundView.vue
@@ -34,11 +34,17 @@
           </p>
         </div>
         <div style="margin-left: auto">
-          <cdx-button @click="toggleEditing()">
-            <cog style="font-size: 6px" v-if="!isRoundEditing" />
-            <close style="font-size: 6px" v-else />
-            {{ isRoundEditing ? $t('montage-btn-cancel') : $t('montage-round-edit') }}
-          </cdx-button>
+          <span
+            v-tooltip="
+              round.status === 'active' ? $t('montage-round-edit-active-warning') : undefined
+            "
+          >
+            <cdx-button :disabled="round.status === 'active'" @click="toggleEditing()">
+              <cog style="font-size: 6px" v-if="!isRoundEditing" />
+              <close style="font-size: 6px" v-else />
+              {{ isRoundEditing ? $t('montage-btn-cancel') : $t('montage-round-edit') }}
+            </cdx-button>
+          </span>
         </div>
       </div>
     </div>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -79,6 +79,7 @@
   "montage-round-file-setting": "Round file settings",
   "montage-round-delete": "Delete round",
   "montage-round-edit": "Edit round",
+  "montage-round-edit-active-warning": "Please pause the round to make edits.",
   "montage-round-save": "Save Round",
   "montage-round-delete-confirm": "Are you sure you want to delete this round?",
   "montage-round-allowed-filetypes": "Allowed filetypes",

--- a/frontend/src/i18n/qqq.json
+++ b/frontend/src/i18n/qqq.json
@@ -82,6 +82,7 @@
 	"montage-round-file-setting": "Label for the file settings in a round.",
 	"montage-round-delete": "Label for the action to delete a round.",
 	"montage-round-edit": "Label for the action to edit a round.",
+	"montage-round-edit-active-warning": "Tooltip shown on the disabled edit button explaining that an active round must be paused before it can be edited.",
 	"montage-round-save": "Label for the action to save changes to a round.",
 	"montage-round-delete-confirm": "Confirmation message for deleting a round.",
 	"montage-round-allowed-filetypes": "Label for the allowed file types setting in a round.",


### PR DESCRIPTION
Fixes: https://github.com/hatnote/montage/issues/589

Screenshots:

<img width="1855" height="962" alt="image" src="https://github.com/user-attachments/assets/7f6f17db-47a9-4734-8ecd-5834f5aa2385" />

<img width="1855" height="962" alt="image" src="https://github.com/user-attachments/assets/93b44965-3904-48a5-833e-c8df77d67604" />
